### PR TITLE
fix: תקן היררכיית כפתורים ומובייל - z-index, עקביות ומניעת חפיפות

### DIFF
--- a/app/frontend/static/css/main.css
+++ b/app/frontend/static/css/main.css
@@ -581,42 +581,13 @@ h6 {
 }
 
 /* Modal Styles - PERFORMANCE OPTIMIZED */
+/* Note: z-index and display/visibility are managed by inline styles in base.html */
+/* This section provides shared styling defaults */
 .modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(5px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  opacity: 0;
-  visibility: hidden;
   transition: all var(--transition-normal);
   /* Performance optimization */
   will-change: opacity, visibility;
-}
-
-.modal-overlay.active {
-  opacity: 1;
-  visibility: visible;
-}
-
-.modal-content {
-  background: white;
-  border-radius: var(--border-radius-xl);
-  box-shadow: var(--shadow-xl);
-  max-width: 500px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  transform: scale(0.9);
-  transition: transform var(--transition-normal);
-  /* Performance optimization */
-  will-change: transform;
 }
 
 .modal-overlay.active .modal-content {
@@ -1043,7 +1014,7 @@ body {
   animation: iconPulse 2s ease-in-out infinite;
 }
 
-* Button sizes */
+/* Button sizes */
 .btn-sm {
   padding: 0.4rem 0.75rem;
   font-size: 0.8rem;
@@ -1214,7 +1185,14 @@ body {
 @media (max-width: 640px) {
   .table td .flex.items-center.gap-2 {
     flex-wrap: wrap;
-    gap: 4px;
+    gap: 6px;
+  }
+
+  /* Ensure action buttons don't stretch full width inside table cards */
+  .table td .btn-xs,
+  .table td .btn-sm {
+    width: auto;
+    flex-shrink: 0;
   }
 }
 

--- a/app/frontend/static/js/core/animations.js
+++ b/app/frontend/static/js/core/animations.js
@@ -228,6 +228,7 @@ class AnimationManager {
 
         modal.classList.add('active');
         document.body.style.overflow = 'hidden';
+        document.body.classList.add('modal-open');
 
         // Use requestAnimationFrame for smooth animation
         requestAnimationFrame(() => {
@@ -250,6 +251,7 @@ class AnimationManager {
         setTimeout(() => {
             modal.classList.remove('active');
             document.body.style.overflow = '';
+            document.body.classList.remove('modal-open');
         }, 300);
     }
 

--- a/app/frontend/templates/finances/transactions.html
+++ b/app/frontend/templates/finances/transactions.html
@@ -88,16 +88,16 @@
                     value="{{ request.query_params.get('tags', '') }}" placeholder="הזן תגיות מופרדות בפסיקים">
             </div>
 
-            <div class="col-span-full flex gap-4">
-                <button type="submit" class="btn btn-primary">
+            <div class="col-span-full flex flex-wrap gap-3">
+                <button type="submit" class="btn btn-primary btn-sm">
                     <i class="fas fa-search mr-2"></i>
                     החל פילטר
                 </button>
-                <a href="/finances/transactions" class="btn btn-outline">
+                <a href="/finances/transactions" class="btn btn-outline btn-sm">
                     <i class="fas fa-times mr-2"></i>
                     נקה פילטר
                 </a>
-                <button type="button" onclick="exportTransactions()" class="btn btn-success">
+                <button type="button" onclick="exportTransactions()" class="btn btn-success btn-sm">
                     <i class="fas fa-download mr-2"></i>
                     ייצא לאקסל
                 </button>
@@ -316,26 +316,26 @@
                                 value="{{ transaction.tags or '' }}" />
                         </td>
                         <td data-label="פעולות">
-                            <div class="flex items-center gap-2">
+                            <div class="flex items-center gap-2 flex-wrap">
                                 <button onclick="editTransactionInline({{ transaction.id }})"
-                                    class="btn btn-outline btn-sm" title="עריכה">
+                                    class="btn btn-outline btn-xs" title="עריכה">
                                     <i class="fas fa-edit"></i>
                                 </button>
                                 <button onclick="saveTransactionInline({{ transaction.id }})"
-                                    class="btn btn-success btn-sm hidden" title="שמור"
+                                    class="btn btn-success btn-xs hidden" title="שמור"
                                     id="save-btn-{{ transaction.id }}">
                                     <i class="fas fa-save"></i>
                                 </button>
                                 <button onclick="cancelEditInline({{ transaction.id }})"
-                                    class="btn btn-warning btn-sm hidden" title="ביטול"
+                                    class="btn btn-warning btn-xs hidden" title="ביטול"
                                     id="cancel-btn-{{ transaction.id }}">
                                     <i class="fas fa-times"></i>
                                 </button>
                                 <button onclick="duplicateTransaction({{ transaction.id }})"
-                                    class="btn btn-outline btn-sm" title="שכפול">
+                                    class="btn btn-outline btn-xs" title="שכפול">
                                     <i class="fas fa-copy"></i>
                                 </button>
-                                <button onclick="deleteTransaction({{ transaction.id }})" class="btn btn-danger btn-sm"
+                                <button onclick="deleteTransaction({{ transaction.id }})" class="btn btn-danger btn-xs"
                                     title="מחיקה">
                                     <i class="fas fa-trash"></i>
                                 </button>
@@ -999,11 +999,6 @@
             opacity: 0;
             transform: translateX(-100%);
         }
-    }
-
-    .btn-sm {
-        padding: 0.5rem 1rem;
-        font-size: 0.875rem;
     }
 
     #transactions-table tbody tr {

--- a/app/frontend/templates/layout/base.html
+++ b/app/frontend/templates/layout/base.html
@@ -30,16 +30,17 @@
     <!-- Custom CSS -->
     <style>
         /* ===== Z-INDEX ARCHITECTURE ===== */
-        /* 
+        /*
         Z-Index Hierarchy (from lowest to highest):
         1. Background elements: 0-10
         2. Main content: 10-50
         3. Sidebar: 100-150
         4. Navigation: 200-250
-        5. Modals/Overlays: 300-400
-        6. Tooltips/Notifications: 500-600
-        7. Floating elements: 700-800
-        8. Loading/Spinners: 900-1000
+        5. Floating Action Button: 300-350
+        6. Drawer overlays: 400-450
+        7. Modals/Overlays: 500-600
+        8. Tooltips/Notifications: 700-800
+        9. Loading/Spinners: 900-1000
         */
 
         [dir="rtl"] {
@@ -58,7 +59,7 @@
             left: 0;
             right: 0;
             z-index: 200;
-            overflow: hidden;
+            overflow: visible;
             padding-top: calc(0.5rem + env(safe-area-inset-top));
         }
 
@@ -68,9 +69,11 @@
             top: 0;
             left: 0;
             right: 0;
-            bottom: 0;
+            height: 64px; /* Constrain shimmer to navbar header height only */
+            overflow: hidden;
             background: linear-gradient(45deg, transparent 30%, rgba(255, 255, 255, 0.1) 50%, transparent 70%);
             animation: shimmer 3s infinite;
+            pointer-events: none;
         }
 
         @keyframes shimmer {
@@ -112,7 +115,7 @@
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
         }
 
-        /* ===== FLOATING ACTION BUTTON (z-index: 700-800) ===== */
+        /* ===== FLOATING ACTION BUTTON (z-index: 300-350) ===== */
         .fab {
             position: fixed;
             bottom: calc(30px + env(safe-area-inset-bottom));
@@ -126,7 +129,7 @@
             cursor: pointer;
             box-shadow: 0 4px 20px rgba(102, 126, 234, 0.4);
             transition: all 0.3s ease;
-            z-index: 700;
+            z-index: 300;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -292,7 +295,7 @@
             left: 100%;
         }
 
-        /* ===== MODAL/OVERLAY LAYER (z-index: 300-400) ===== */
+        /* ===== MODAL/OVERLAY LAYER (z-index: 500-600) ===== */
         .modal-overlay {
             position: fixed;
             top: 0;
@@ -300,7 +303,7 @@
             right: 0;
             bottom: 0;
             background: rgba(0, 0, 0, 0.5);
-            z-index: 300;
+            z-index: 500;
             display: none;
             align-items: center;
             justify-content: center;
@@ -320,14 +323,14 @@
             background: white;
             border-radius: 12px;
             box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-            z-index: 350;
+            z-index: 550;
             position: relative;
             max-width: 90vw;
             max-height: 90vh;
             overflow: auto;
         }
 
-        /* ===== TOAST/NOTIFICATION LAYER (z-index: 500-600) ===== */
+        /* ===== TOAST/NOTIFICATION LAYER (z-index: 700-800) ===== */
         .toast {
             position: fixed;
             top: 20px;
@@ -336,13 +339,21 @@
             border-radius: 8px;
             box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
             padding: 16px 20px;
-            z-index: 500;
+            z-index: 700;
             transform: translateX(100%);
             transition: transform 0.3s ease;
         }
 
         .toast.show {
             transform: translateX(0);
+        }
+
+        /* Hide FAB when modal or drawer is open */
+        .modal-overlay.active ~ .fab,
+        body.modal-open .fab {
+            opacity: 0;
+            pointer-events: none;
+            transform: scale(0.5);
         }
 
         /* ===== LOADING/SPINNER LAYER (z-index: 900-1000) ===== */
@@ -369,7 +380,7 @@
             max-width: 85vw;
             background: white;
             box-shadow: -4px 0 20px rgba(0,0,0,0.15);
-            z-index: 450;
+            z-index: 420;
             transform: translateX(100%);
             transition: transform 0.3s ease-in-out;
             overflow-y: auto;
@@ -381,7 +392,7 @@
             position: fixed;
             inset: 0;
             background: rgba(0,0,0,0.5);
-            z-index: 440;
+            z-index: 410;
             display: none;
         }
         .drawer-overlay.open {
@@ -453,7 +464,7 @@
 
 <body class="bg-gray-50 min-h-screen full-viewport-safe">
     <!-- Main Navigation Bar -->
-    <nav class="nav-gradient text-white shadow-lg relative z-50">
+    <nav class="nav-gradient text-white shadow-lg">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-16">
                 <!-- Logo/Brand -->

--- a/app/frontend/templates/pages/recurrences.html
+++ b/app/frontend/templates/pages/recurrences.html
@@ -27,12 +27,12 @@
                {% if request.query_params.get('only_active') in ['1','true','True','on'] %}checked{% endif %}>
         <label for="only_active" class="text-sm font-medium">רק פעילים</label>
       </div>
-      <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
-        החל סינון
+      <button type="submit" class="btn btn-primary btn-sm">
+        <i class="fas fa-filter mr-1"></i>החל סינון
       </button>
       {% if request.query_params.get('category_id') or request.query_params.get('only_active') or request.query_params.get('month') %}
-        <a href="/finances/recurrences" class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600">
-          נקה סינון
+        <a href="/finances/recurrences" class="btn btn-outline btn-sm">
+          <i class="fas fa-times mr-1"></i>נקה סינון
         </a>
       {% endif %}
     </form>

--- a/app/frontend/templates/pages/recurrences_active.html
+++ b/app/frontend/templates/pages/recurrences_active.html
@@ -63,7 +63,9 @@
       <input type="number" name="weekday" min="0" max="6" class="w-full border border-gray-300 rounded px-3 py-2" />
     </div>
     <div class="md:col-span-2 text-right">
-      <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">שמור</button>
+      <button type="submit" class="btn btn-primary">
+        <i class="fas fa-save mr-2"></i>שמור
+      </button>
     </div>
   </form>
 </div>
@@ -89,12 +91,12 @@
           {% endfor %}
         </select>
       </div>
-      <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
-        החל סינון
+      <button type="submit" class="btn btn-primary btn-sm">
+        <i class="fas fa-filter mr-1"></i>החל סינון
       </button>
       {% if request.query_params.get('category_id') %}
-        <a href="/finances/recurrences/active" class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600">
-          נקה סינון
+        <a href="/finances/recurrences/active" class="btn btn-outline btn-sm">
+          <i class="fas fa-times mr-1"></i>נקה סינון
         </a>
       {% endif %}
     </form>

--- a/app/frontend/templates/partials/income/form.html
+++ b/app/frontend/templates/partials/income/form.html
@@ -31,7 +31,9 @@
       <input type="text" name="notes" class="w-full border border-gray-300 rounded px-3 py-2" />
     </div>
     <div class="md:col-span-2 text-right">
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">שמור הכנסה</button>
+      <button type="submit" class="btn btn-success">
+        <i class="fas fa-save mr-2"></i>שמור הכנסה
+      </button>
     </div>
   </form>
 </div>

--- a/app/frontend/templates/partials/recurrences/edit_row.html
+++ b/app/frontend/templates/partials/recurrences/edit_row.html
@@ -59,27 +59,28 @@
       <option value="0" {% if not recurrence['active'] %}selected{% endif %}>לא</option>
     </select>
   </td>
-  <td class="space-x-2">
+  <td>
     <!-- הטופס עצמו -->
     <form id="edit-recurrence-{{ recurrence['id'] }}"
           hx-post="/recurrences/{{ recurrence['id'] }}/edit-inline"
           hx-target="#recurrence-row-{{ recurrence['id'] }}"
           hx-swap="outerHTML"
           hx-disabled-elt="this">
-
     </form>
 
-    <button type="submit" form="edit-recurrence-{{ recurrence['id'] }}"
-            class="px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700">
-      שמירה
-    </button>
+    <div class="flex items-center gap-2 flex-wrap">
+      <button type="submit" form="edit-recurrence-{{ recurrence['id'] }}"
+              class="btn btn-success btn-xs">
+        <i class="fas fa-save mr-1"></i>שמירה
+      </button>
 
-    <button type="button"
-            class="px-3 py-1 rounded border hover:bg-gray-50"
-            hx-get="/recurrences/{{ recurrence['id'] }}/row"
-            hx-target="#recurrence-row-{{ recurrence['id'] }}"
-            hx-swap="outerHTML">
-      ביטול
-    </button>
+      <button type="button"
+              class="btn btn-outline btn-xs"
+              hx-get="/recurrences/{{ recurrence['id'] }}/row"
+              hx-target="#recurrence-row-{{ recurrence['id'] }}"
+              hx-swap="outerHTML">
+        <i class="fas fa-times mr-1"></i>ביטול
+      </button>
+    </div>
   </td>
 </tr>

--- a/app/frontend/templates/partials/transactions/form.html
+++ b/app/frontend/templates/partials/transactions/form.html
@@ -39,7 +39,9 @@
       <input type="text" name="notes" class="w-full border border-gray-300 rounded px-3 py-2" />
     </div>
     <div class="md:col-span-2 text-right">
-      <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">שמור</button>
+      <button type="submit" class="btn btn-primary">
+        <i class="fas fa-save mr-2"></i>שמור
+      </button>
     </div>
   </form>
 </div>

--- a/app/frontend/templates/partials/transactions/row.html
+++ b/app/frontend/templates/partials/transactions/row.html
@@ -9,14 +9,16 @@
   <td>{{ tx['account_name'] or '-' }}</td>
   <td>{{ tx['notes'] or '' }}</td>
   <td>{{ tx['tags'] or '' }}</td>
-  <td class="space-x-2">
-    <button class="px-3 py-1 rounded bg-blue-600 text-white"
-            hx-get="/transactions/{{ tx['id'] }}/edit-inline"
-            hx-target="#txrow-{{ tx['id'] }}" hx-swap="outerHTML">עריכה</button>
-    <button class="px-3 py-1 rounded bg-red-600 text-white"
-            hx-post="/transactions/{{ tx['id'] }}/delete-inline"
-            hx-target="#txrow-{{ tx['id'] }}" hx-swap="outerHTML"
-            hx-confirm="למחוק את העסקה? הפעולה בלתי הפיכה.">מחיקה</button>
+  <td>
+    <div class="flex items-center gap-2 flex-wrap">
+      <button class="btn btn-outline btn-xs"
+              hx-get="/transactions/{{ tx['id'] }}/edit-inline"
+              hx-target="#txrow-{{ tx['id'] }}" hx-swap="outerHTML">עריכה</button>
+      <button class="btn btn-danger btn-xs"
+              hx-post="/transactions/{{ tx['id'] }}/delete-inline"
+              hx-target="#txrow-{{ tx['id'] }}" hx-swap="outerHTML"
+              hx-confirm="למחוק את העסקה? הפעולה בלתי הפיכה.">מחיקה</button>
+    </div>
   </td>
 </tr>
 {% else %}
@@ -72,7 +74,7 @@
            class="w-full border rounded px-2 py-1">
   </td>
 
-  <td class="space-x-2">
+  <td>
     <!-- הטופס עצמו: יושב בתא הפעולות -->
     <form id="edit-{{ tx['id'] }}"
           hx-post="/transactions/{{ tx['id'] }}/edit-inline"
@@ -81,18 +83,20 @@
           hx-disabled-elt="this">
     </form>
 
-    <button type="submit" form="edit-{{ tx['id'] }}"
-            class="px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700">
-      שמירה
-    </button>
+    <div class="flex items-center gap-2 flex-wrap">
+      <button type="submit" form="edit-{{ tx['id'] }}"
+              class="btn btn-success btn-xs">
+        <i class="fas fa-save mr-1"></i>שמירה
+      </button>
 
-    <button type="button"
-            class="px-3 py-1 rounded border hover:bg-gray-50"
-            hx-get="/transactions/{{ tx['id'] }}/row"
-            hx-target="#txrow-{{ tx['id'] }}"
-            hx-swap="outerHTML">
-      ביטול
-    </button>
+      <button type="button"
+              class="btn btn-outline btn-xs"
+              hx-get="/transactions/{{ tx['id'] }}/row"
+              hx-target="#txrow-{{ tx['id'] }}"
+              hx-swap="outerHTML">
+        <i class="fas fa-times mr-1"></i>ביטול
+      </button>
+    </div>
   </td>
 </tr>
 {% endif %}


### PR DESCRIPTION
- תיקון שגיאת CSS (חסר /* בתחילת הערה) שגרמה לשבירת כללי CSS
- שינוי ארכיטקטורת z-index: FAB(300) < Drawers(410-420) < Modals(500-550) < Toasts(700)
- הסרת כפילויות CSS סותרות (modal-overlay, modal-content, btn-sm)
- הוספת flex-wrap לכפתורי פעולות בטבלת עסקאות (5 כפתורים)
- המרת כפתורי מצב עריכה לשימוש ב-.btn classes עקביים
- אחידות כפתורי סינון בכל הדפים
- הסרת Tailwind classes מטעים ב-nav (relative z-50 שנדרסו)
- הסתרת FAB כשמודאל פתוח למניעת חפיפת כפתורים
- תיקון overflow:hidden ב-navbar שחתך תפריט מובייל

https://claude.ai/code/session_014ogExZcpfsnWoyDGuzFwqY