### PR TITLE
Improve expenses page desktop UX with sidebar and redesigned layout

### DIFF
--- a/app/frontend/templates/finances/base.html
+++ b/app/frontend/templates/finances/base.html
@@ -3,10 +3,11 @@
 {% block title %}{% block finances_title %}פיננסים{% endblock %} - המנביטים{% endblock %}
 
 {% block content %}
-<!-- Finances Drawer Overlay -->
+
+<!-- Mobile Only: Drawer Overlay -->
 <div id="fin-overlay" class="drawer-overlay" onclick="toggleFinDrawer()"></div>
 
-<!-- Finances Right Drawer -->
+<!-- Mobile Only: Finances Drawer -->
 <div id="fin-drawer" class="section-drawer" dir="rtl">
 
     <!-- Drawer Header -->
@@ -28,7 +29,7 @@
         </button>
     </div>
 
-    <!-- Navigation Links -->
+    <!-- Mobile Navigation Links -->
     <nav class="p-3 space-y-1">
 
         <a href="/finances" onclick="toggleFinDrawer()"
@@ -118,8 +119,114 @@
     </nav>
 </div>
 
-<!-- Section Sub-header -->
-<div class="section-subheader bg-white border-b border-gray-200 shadow-sm" dir="rtl">
+<!-- Desktop Only: Persistent Sidebar -->
+<aside class="hidden lg:flex lg:flex-col fixed bg-white border-l border-gray-200 shadow-lg overflow-y-auto"
+       style="right: 0; top: calc(64px + env(safe-area-inset-top, 0px)); bottom: 0; width: 16rem; z-index: 50;"
+       dir="rtl">
+
+    <!-- Sidebar Header -->
+    <div class="flex items-center gap-3 p-5 bg-gradient-to-l from-blue-700 to-blue-900 flex-shrink-0">
+        <div class="w-10 h-10 bg-white/20 rounded-xl flex items-center justify-center flex-shrink-0">
+            <i class="fas fa-wallet text-white text-lg"></i>
+        </div>
+        <div>
+            <h2 class="text-lg font-bold text-white leading-tight">פיננסים</h2>
+            <p class="text-blue-200 text-xs">ניהול כספים</p>
+        </div>
+    </div>
+
+    <!-- Desktop Navigation Links -->
+    <nav class="p-3 space-y-1 flex-1">
+
+        <a href="/finances"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if request.path == '/finances' %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if request.path == '/finances' %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-gauge text-sm {% if request.path == '/finances' %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>דשבורד</span>
+            {% if request.path == '/finances' %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/transactions"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'transactions' in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'transactions' in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-exchange-alt text-sm {% if 'transactions' in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>עסקאות</span>
+            {% if 'transactions' in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/income"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'income' in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'income' in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-shekel-sign text-sm {% if 'income' in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>הכנסות</span>
+            {% if 'income' in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/recurrences"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'recurrences' in request.path and 'recurrences/active' not in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'recurrences' in request.path and 'recurrences/active' not in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-repeat text-sm {% if 'recurrences' in request.path and 'recurrences/active' not in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>הוצאות קבועות</span>
+            {% if 'recurrences' in request.path and 'recurrences/active' not in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/recurrences/active"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'recurrences/active' in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'recurrences/active' in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-toggle-on text-sm {% if 'recurrences/active' in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>ניהול הוצאות קבועות</span>
+            {% if 'recurrences/active' in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/statistics"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'statistics' in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'statistics' in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-chart-line text-sm {% if 'statistics' in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>סטטיסטיקות</span>
+            {% if 'statistics' in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+        <a href="/finances/backup"
+            class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
+                   {% if 'backup' in request.path %}bg-blue-50 text-blue-700{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
+            <div class="w-8 h-8 rounded-lg {% if 'backup' in request.path %}bg-blue-100{% else %}bg-gray-100{% endif %} flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-database text-sm {% if 'backup' in request.path %}text-blue-600{% else %}text-gray-500{% endif %}"></i>
+            </div>
+            <span>גיבוי</span>
+            {% if 'backup' in request.path %}
+            <span class="mr-auto w-2 h-2 rounded-full bg-blue-500"></span>
+            {% endif %}
+        </a>
+
+    </nav>
+</aside>
+
+<!-- Mobile Only: Section Sub-header -->
+<div class="lg:hidden section-subheader bg-white border-b border-gray-200 shadow-sm" dir="rtl">
     <div class="flex items-center justify-between px-4 py-3">
         <div class="flex items-center gap-2 min-w-0">
             <i class="fas fa-wallet text-blue-600 text-sm flex-shrink-0"></i>
@@ -135,8 +242,8 @@
     </div>
 </div>
 
-<!-- Page Content -->
-<div class="bg-gray-50 min-h-screen p-4 sm:p-6 pb-10" dir="rtl">
+<!-- Page Content: pushed right on desktop to clear the sidebar -->
+<div class="bg-gray-50 min-h-screen p-4 sm:p-6 lg:p-8 pb-10 lg:mr-64" dir="rtl">
     {% block finances_content %}{% endblock %}
 </div>
 

--- a/app/frontend/templates/finances/transactions.html
+++ b/app/frontend/templates/finances/transactions.html
@@ -1,19 +1,43 @@
 {% extends "finances/base.html" %}
 {% block finances_title %}עסקאות{% endblock %}
+{% block finances_breadcrumb %}עסקאות{% endblock %}
 
 {% block finances_content %}
-<div class="w-full animate-sequence">
+{% set has_active_filters = request.query_params.get('category_id') or request.query_params.get('date_from') or request.query_params.get('date_to') or request.query_params.get('amount_min') or request.query_params.get('amount_max') or request.query_params.get('user_id') or request.query_params.get('account_id') or request.query_params.get('tags') %}
 
+<!-- Page Header -->
+<div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6 animate-sequence">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900 flex items-center gap-3">
+            <div class="w-10 h-10 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                <i class="fas fa-exchange-alt text-blue-600"></i>
+            </div>
+            עסקאות
+        </h1>
+        <p class="text-sm text-gray-500 mt-1 pr-13">ניהול וצפייה בכל ההוצאות</p>
+    </div>
+    <button onclick="openAddModal()" class="btn btn-primary flex-shrink-0">
+        <i class="fas fa-plus mr-2"></i>
+        הוסף עסקה חדשה
+    </button>
 </div>
 
 <!-- Advanced Filters -->
 <div class="card mb-6 animate-sequence">
-    <div class="card-header">
-        <h2 class="text-xl font-semibold text-gray-900 flex items-center">
-            <i class="fas fa-filter mr-3 text-blue-600"></i>
-            פילטרים מתקדמים
-        </h2>
+    <div class="card-header cursor-pointer select-none" onclick="toggleFilters()" style="border-bottom: none;" id="filters-header">
+        <div class="flex items-center justify-between">
+            <h2 class="text-xl font-semibold text-gray-900 flex items-center gap-3">
+                <i class="fas fa-filter text-blue-600"></i>
+                פילטרים
+                {% if has_active_filters %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-blue-100 text-blue-700">פעיל</span>
+                {% endif %}
+            </h2>
+            <i class="fas fa-chevron-down text-gray-400 transition-transform duration-200" id="filter-chevron"
+               style="{% if not has_active_filters %}transform: rotate(-90deg);{% endif %}"></i>
+        </div>
     </div>
+    <div id="filters-body" {% if not has_active_filters %}style="display:none; border-top: none;"{% else %}style="border-top: 1px solid #e5e7eb;"{% endif %}>
     <div class="card-body">
         <form method="GET" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 
@@ -104,61 +128,81 @@
             </div>
         </form>
     </div>
+    </div>
 </div>
 
-<!-- Add Transaction Button -->
-<div class="mb-6">
-    <button onclick="openAddModal()" class="btn btn-primary">
-        <i class="fas fa-plus mr-2"></i>
-        הוסף עסקה חדשה
-    </button>
-</div>
+<!-- Stats Cards Row -->
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6 animate-sequence">
 
-<!-- Total Sum Card -->
-<div class="card mb-6 bg-gradient-to-r from-blue-50 to-indigo-50 animate-sequence">
-    <div class="card-body">
-        <div class="flex items-center justify-between">
-            <div class="flex items-center">
-                <div class="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center mr-4">
-                    <i class="fas fa-calculator text-white text-xl"></i>
+    <!-- Total Expenses -->
+    <div class="card bg-gradient-to-br from-blue-50 to-indigo-50" style="transform: none;">
+        <div class="card-body py-4">
+            <div class="flex items-center gap-4">
+                <div class="w-12 h-12 bg-blue-600 rounded-xl flex items-center justify-center flex-shrink-0">
+                    <i class="fas fa-shekel-sign text-white text-lg"></i>
                 </div>
-                <div>
-                    <h3 class="text-sm font-medium text-gray-600">סה"כ הוצאות מסוננות</h3>
-                    <p class="text-3xl font-bold text-blue-900" dir="ltr">₪{{ total_sum | round(2) }}</p>
+                <div class="min-w-0">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-0.5">סה"כ הוצאות</p>
+                    <p class="text-2xl font-bold text-blue-900 truncate" dir="ltr">₪{{ total_sum | round(2) }}</p>
                 </div>
-            </div>
-            <div class="text-sm text-gray-600">
-                {{ pagination.total }} עסקאות
             </div>
         </div>
     </div>
+
+    <!-- Transaction Count -->
+    <div class="card bg-gradient-to-br from-purple-50 to-pink-50" style="transform: none;">
+        <div class="card-body py-4">
+            <div class="flex items-center gap-4">
+                <div class="w-12 h-12 bg-purple-600 rounded-xl flex items-center justify-center flex-shrink-0">
+                    <i class="fas fa-list-ol text-white text-lg"></i>
+                </div>
+                <div class="min-w-0">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-0.5">מספר עסקאות</p>
+                    <p class="text-2xl font-bold text-purple-900">{{ pagination.total }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Average -->
+    <div class="card bg-gradient-to-br from-green-50 to-teal-50" style="transform: none;">
+        <div class="card-body py-4">
+            <div class="flex items-center gap-4">
+                <div class="w-12 h-12 bg-green-600 rounded-xl flex items-center justify-center flex-shrink-0">
+                    <i class="fas fa-calculator text-white text-lg"></i>
+                </div>
+                <div class="min-w-0">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-0.5">ממוצע לעסקה</p>
+                    <p class="text-2xl font-bold text-green-900 truncate" dir="ltr">
+                        {% if pagination.total > 0 %}₪{{ (total_sum / pagination.total) | round(2) }}{% else %}₪0{% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </div>
 
 <!-- Transactions Table -->
 <div class="card animate-sequence" id="transactions-table">
     <div class="card-header">
-        <div class="flex justify-between items-center">
-            <h2 class="text-xl font-semibold text-gray-900 flex items-center">
-                <i class="fas fa-list mr-3 text-blue-600"></i>
-                עסקאות
-            </h2>
-            <div class="flex items-center gap-4">
-                <div class="text-sm text-gray-600">
-                    מציג {{ (pagination.page - 1) * pagination.per_page + 1 }} עד {{ pagination.page *
-                    pagination.per_page if pagination.page * pagination.per_page < pagination.total else
-                        pagination.total }} מתוך {{ pagination.total }} עסקאות </div>
-                        <div class="flex items-center gap-2">
-                            <label for="sort_by" class="text-sm font-medium text-gray-700">מיון:</label>
-                            <select id="sort_by" class="form-select text-sm" onchange="sortTransactions()">
-                                <option value="date_desc">תאריך (חדש לישן)</option>
-                                <option value="date_asc">תאריך (ישן לחדש)</option>
-                                <option value="amount_desc">סכום (גבוה לנמוך)</option>
-                                <option value="amount_asc">סכום (נמוך לגבוה)</option>
-                            </select>
-                        </div>
-                </div>
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <div class="text-sm text-gray-500 font-medium">
+                מציג
+                <span class="font-semibold text-gray-800">{{ (pagination.page - 1) * pagination.per_page + 1 }}–{{ pagination.page * pagination.per_page if pagination.page * pagination.per_page < pagination.total else pagination.total }}</span>
+                מתוך <span class="font-semibold text-gray-800">{{ pagination.total }}</span> עסקאות
+            </div>
+            <div class="flex items-center gap-2">
+                <label for="sort_by" class="text-sm font-medium text-gray-600 whitespace-nowrap">מיון:</label>
+                <select id="sort_by" class="form-select text-sm" style="padding: 0.4rem 0.75rem;" onchange="sortTransactions()">
+                    <option value="date_desc">תאריך (חדש לישן)</option>
+                    <option value="date_asc">תאריך (ישן לחדש)</option>
+                    <option value="amount_desc">סכום (גבוה לנמוך)</option>
+                    <option value="amount_asc">סכום (נמוך לגבוה)</option>
+                </select>
             </div>
         </div>
+    </div>
 
         <div class="overflow-x-auto">
             <table class="table">
@@ -489,6 +533,24 @@
 </div>
 
 <script>
+    // Filter panel toggle
+    function toggleFilters() {
+        const body = document.getElementById('filters-body');
+        const chevron = document.getElementById('filter-chevron');
+        const header = document.getElementById('filters-header');
+        const isVisible = body.style.display !== 'none';
+        if (isVisible) {
+            body.style.display = 'none';
+            chevron.style.transform = 'rotate(-90deg)';
+            header.style.borderBottom = 'none';
+        } else {
+            body.style.display = 'block';
+            body.style.borderTop = '1px solid #e5e7eb';
+            chevron.style.transform = 'rotate(0deg)';
+            header.style.borderBottom = '';
+        }
+    }
+
     // Enhanced JavaScript functionality
     let currentSort = 'date_desc';
 
@@ -990,20 +1052,41 @@
 
 <style>
     @keyframes slideOut {
-        from {
-            opacity: 1;
-            transform: translateX(0);
-        }
-
-        to {
-            opacity: 0;
-            transform: translateX(-100%);
-        }
+        from { opacity: 1; transform: translateX(0); }
+        to   { opacity: 0; transform: translateX(-100%); }
     }
 
     #transactions-table tbody tr {
         animation: fadeIn 0.6s ease-out;
         animation-fill-mode: both;
+    }
+
+    /* Filter toggle chevron transition */
+    #filter-chevron {
+        transition: transform 0.2s ease;
+    }
+
+    /* Stats cards: disable lift-on-hover for static info cards */
+    .stats-card:hover {
+        transform: none !important;
+    }
+
+    /* Table: tighten up cell padding on desktop for more rows visible */
+    @media (min-width: 1024px) {
+        #transactions-table .table td,
+        #transactions-table .table th {
+            padding: 0.65rem 1rem;
+        }
+    }
+
+    /* Action buttons: keep them compact and on one line */
+    #transactions-table .table td:last-child > div {
+        flex-wrap: nowrap;
+    }
+
+    /* Better row hover contrast */
+    #transactions-table .table tbody tr:hover {
+        background: linear-gradient(135deg, #f0f4ff 0%, #e8eeff 100%);
     }
 </style>
 {% endblock %}


### PR DESCRIPTION
- finances/base.html: Add persistent fixed sidebar (16rem) for desktop (lg+),
  hidden on mobile which still uses the existing drawer. Content area pushed
  right with lg:mr-64 to clear the sidebar.
- transactions.html: Add page header with title + "Add Transaction" button.
  Filters panel is now collapsible with chevron toggle (auto-open when filters
  are active). Single stats card replaced with 3-card grid showing total,
  count, and average. Table header simplified with cleaner pagination info.
  Added compact table cell padding on desktop.

https://claude.ai/code/session_01FrF41e8JK43mbQ1fBVDLvE