### PR TITLE
Improve contrast and readability of form labels and status badges

### DIFF
--- a/app/frontend/templates/wedding/vendor_detail.html
+++ b/app/frontend/templates/wedding/vendor_detail.html
@@ -30,7 +30,7 @@
 } %}
 
 {% set STATUS_COLORS = {
-    'not_contacted':   'bg-gray-100 text-gray-600',
+    'not_contacted':   'bg-gray-200 text-gray-700',
     'quote_received':  'bg-blue-100 text-blue-700',
     'contract_signed': 'bg-amber-100 text-amber-700',
     'deal_closed':     'bg-rose-100 text-rose-700',
@@ -78,13 +78,13 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">שם הספק</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">שם הספק</label>
                     <input type="text" name="name" value="{{ vendor.name }}"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400">
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">קטגוריה</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">קטגוריה</label>
                     <select name="category" class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400">
                         <option value="chuppah"       {% if vendor.category == 'chuppah' %}selected{% endif %}>ספק חופה</option>
                         <option value="catering"      {% if vendor.category == 'catering' %}selected{% endif %}>קייטרינג</option>
@@ -104,21 +104,21 @@
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">איש קשר</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">איש קשר</label>
                     <input type="text" name="contact_name" value="{{ vendor.contact_name or '' }}"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                            placeholder="שם איש קשר">
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">טלפון</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">טלפון</label>
                     <input type="text" name="phone" value="{{ vendor.phone or '' }}" dir="ltr"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                            placeholder="050-0000000">
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">סטטוס</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">סטטוס</label>
                     <select name="status" class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400">
                         <option value="not_contacted"   {% if vendor.status == 'not_contacted' %}selected{% endif %}>לא נוצר קשר</option>
                         <option value="quote_received"  {% if vendor.status == 'quote_received' %}selected{% endif %}>הצעת מחיר התקבלה</option>
@@ -130,14 +130,14 @@
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">סכום מקדמה (₪)</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">סכום מקדמה (₪)</label>
                     <input type="number" name="deposit_amount" value="{{ vendor.deposit_amount or '' }}" dir="ltr"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                            placeholder="0">
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">תאריך תשלום מקדמה</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">תאריך תשלום מקדמה</label>
                     <input type="date" name="deposit_paid_date" value="{{ vendor.deposit_paid_date or '' }}"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400">
                 </div>
@@ -153,7 +153,7 @@
                     </div>
 
                     <!-- Column Headers (desktop only) -->
-                    <div class="hidden sm:grid gap-1 mb-1 px-1 text-xs text-gray-400 font-medium"
+                    <div class="hidden sm:grid gap-1 mb-1 px-1 text-xs text-gray-600 font-medium"
                          style="grid-template-columns: 1fr 60px 90px 70px 28px">
                         <span>תיאור</span>
                         <span class="text-center">כמות</span>
@@ -167,11 +167,11 @@
 
                     <!-- Totals -->
                     <div id="quote-totals" class="mt-3 pt-3 border-t border-gray-200 space-y-1 text-sm hidden">
-                        <div class="flex justify-between text-gray-500">
+                        <div class="flex justify-between text-gray-600">
                             <span>סה"כ לפני מע"מ</span>
                             <span id="tot-pre-vat" class="font-medium tabular-nums">₪0</span>
                         </div>
-                        <div class="flex justify-between text-gray-500">
+                        <div class="flex justify-between text-gray-600">
                             <span>מע"מ (17%)</span>
                             <span id="tot-vat" class="font-medium tabular-nums">₪0</span>
                         </div>
@@ -183,7 +183,7 @@
 
                     <!-- Manual price (shown when no items) -->
                     <div id="manual-price-wrap" class="mt-3">
-                        <label class="block text-xs font-medium text-gray-500 mb-1">
+                        <label class="block text-xs font-medium text-gray-700 mb-1">
                             הצעת מחיר (₪)
                             <span id="manual-price-note" class="text-gray-400 hidden"> — מחושב אוטומטית מהמרכיבים</span>
                         </label>
@@ -205,28 +205,28 @@
                 <!-- ─────────────────────────────────────────────────────────── -->
 
                 <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-gray-500 mb-1">מה כולל ההצעה</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">מה כולל ההצעה</label>
                     <textarea name="what_included" rows="3"
                               class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                               placeholder="פירוט השירות המוצע...">{{ vendor.what_included or '' }}</textarea>
                 </div>
 
                 <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-gray-500 mb-1">הערות</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">הערות</label>
                     <textarea name="notes" rows="3"
                               class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                               placeholder="הערות נוספות, קישורים, מידע נוסף...">{{ vendor.notes or '' }}</textarea>
                 </div>
 
                 <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-gray-500 mb-1">📍 מיקום</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">📍 מיקום</label>
                     <input type="text" name="location" value="{{ vendor.location or '' }}"
                            class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
                            placeholder="כתובת / שם המקום">
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">📸 אינסטגרם</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">📸 אינסטגרם</label>
                     <div class="flex gap-2 items-center">
                         <input type="url" name="instagram_url" value="{{ vendor.instagram_url or '' }}" dir="ltr"
                                class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
@@ -239,7 +239,7 @@
                 </div>
 
                 <div>
-                    <label class="block text-xs font-medium text-gray-500 mb-1">👍 פייסבוק</label>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">👍 פייסבוק</label>
                     <div class="flex gap-2 items-center">
                         <input type="url" name="facebook_url" value="{{ vendor.facebook_url or '' }}" dir="ltr"
                                class="border border-gray-200 rounded-xl px-4 py-3 w-full text-base focus:outline-none focus:ring-2 focus:ring-rose-300 focus:border-rose-400"
@@ -338,7 +338,7 @@ const STATUS_LABELS = {
     fully_paid:      'שולם במלואו'
 };
 const STATUS_COLORS = {
-    not_contacted:   'bg-gray-100 text-gray-600',
+    not_contacted:   'bg-gray-200 text-gray-700',
     quote_received:  'bg-blue-100 text-blue-700',
     contract_signed: 'bg-amber-100 text-amber-700',
     deal_closed:     'bg-rose-100 text-rose-700',
@@ -432,12 +432,12 @@ function makeItemRow(item) {
             </div>
             <div class="grid grid-cols-3 gap-2">
                 <div>
-                    <span class="text-xs text-gray-400">כמות</span>
+                    <span class="text-xs text-gray-600">כמות</span>
                     <input type="number" value="${qty}" min="0" step="any"
                            class="item-qty border border-gray-200 rounded-lg px-2 py-2 text-base w-full text-center focus:outline-none focus:ring-1 focus:ring-rose-300 bg-white" dir="ltr">
                 </div>
                 <div>
-                    <span class="text-xs text-gray-400">מחיר (₪)</span>
+                    <span class="text-xs text-gray-600">מחיר (₪)</span>
                     <input type="number" value="${price}" min="0" step="any" placeholder="0"
                            class="item-price border border-gray-200 rounded-lg px-2 py-2 text-base w-full text-center focus:outline-none focus:ring-1 focus:ring-rose-300 bg-white" dir="ltr">
                 </div>
@@ -613,7 +613,7 @@ function makeFileRow(f) {
         }
         <div class="flex-1 min-w-0">
             <div class="text-sm font-medium text-gray-800 truncate">${escHtml(f.original_name)}</div>
-            <div class="text-xs text-gray-400">${sizeMB} MB</div>
+            <div class="text-xs text-gray-500">${sizeMB} MB</div>
         </div>
         <a href="/api/wedding/files/${f.id}" target="_blank" rel="noopener"
            class="shrink-0 text-xs text-rose-600 hover:text-rose-800 font-medium px-2 py-1.5 rounded-lg hover:bg-rose-50 min-h-[36px] flex items-center">

--- a/app/frontend/templates/wedding/vendors.html
+++ b/app/frontend/templates/wedding/vendors.html
@@ -46,7 +46,7 @@
 } %}
 
 {% set STATUS_COLORS = {
-    'not_contacted':   'bg-gray-100 text-gray-500',
+    'not_contacted':   'bg-gray-200 text-gray-700',
     'quote_received':  'bg-blue-100 text-blue-700',
     'contract_signed': 'bg-amber-100 text-amber-700',
     'deal_closed':     'bg-rose-100 text-rose-700',
@@ -92,15 +92,15 @@
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-3 text-center">
             <div class="text-2xl font-bold text-gray-800">{{ ns.total }}</div>
-            <div class="text-xs text-gray-500 mt-0.5">ספקים בסה"כ</div>
+            <div class="text-xs text-gray-600 mt-0.5">ספקים בסה"כ</div>
         </div>
         <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-3 text-center">
             <div class="text-2xl font-bold text-rose-600">{{ ns.chosen }}</div>
-            <div class="text-xs text-gray-500 mt-0.5">נבחרו</div>
+            <div class="text-xs text-gray-600 mt-0.5">נבחרו</div>
         </div>
         <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-3 text-center">
             <div class="text-2xl font-bold text-blue-600">{{ ns.quote_count }}</div>
-            <div class="text-xs text-gray-500 mt-0.5">הצעות פתוחות</div>
+            <div class="text-xs text-gray-600 mt-0.5">הצעות פתוחות</div>
         </div>
         <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-3 text-center">
             {% if ns.committed > 0 %}
@@ -108,7 +108,7 @@
             {% else %}
             <div class="text-xl font-bold text-gray-400">—</div>
             {% endif %}
-            <div class="text-xs text-gray-500 mt-0.5">סה"כ מחויב</div>
+            <div class="text-xs text-gray-600 mt-0.5">סה"כ מחויב</div>
         </div>
     </div>
 
@@ -166,7 +166,7 @@
                                     {% endif %}
                                 </div>
                                 {% if v.contact_name or v.phone %}
-                                <div class="text-xs text-gray-400 mt-0.5">
+                                <div class="text-xs text-gray-500 mt-0.5">
                                     {% if v.contact_name %}{{ v.contact_name }}{% endif %}
                                     {% if v.contact_name and v.phone %} · {% endif %}
                                     {% if v.phone %}<span dir="ltr">{{ v.phone }}</span>{% endif %}
@@ -182,7 +182,7 @@
                                     {% endif %}
                                 </div>
                                 {% endif %}
-                                <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium {{ STATUS_COLORS.get(v.status, 'bg-gray-100 text-gray-500') }}">
+                                <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium {{ STATUS_COLORS.get(v.status, 'bg-gray-200 text-gray-700') }}">
                                     {{ STATUS_LABELS.get(v.status, v.status) }}
                                 </span>
                             </div>
@@ -247,12 +247,12 @@
                                 {% if is_chosen %}<span class="text-xs bg-rose-600 text-white px-1.5 py-0.5 rounded-full">✓ נבחר</span>{% endif %}
                             </div>
                             {% if v.contact_name or v.phone %}
-                            <div class="text-xs text-gray-400 mt-0.5">{{ v.contact_name }}{% if v.contact_name and v.phone %} · {% endif %}<span dir="ltr">{{ v.phone }}</span></div>
+                            <div class="text-xs text-gray-500 mt-0.5">{{ v.contact_name }}{% if v.contact_name and v.phone %} · {% endif %}<span dir="ltr">{{ v.phone }}</span></div>
                             {% endif %}
                         </div>
                         <div class="text-left shrink-0">
                             {% if v.price_quoted %}<div class="text-sm font-bold text-gray-800" dir="ltr">₪{{ "{:,.0f}".format(v.price_quoted) }}</div>{% endif %}
-                            <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium {{ STATUS_COLORS.get(v.status, 'bg-gray-100 text-gray-500') }}">{{ STATUS_LABELS.get(v.status, v.status) }}</span>
+                            <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium {{ STATUS_COLORS.get(v.status, 'bg-gray-200 text-gray-700') }}">{{ STATUS_LABELS.get(v.status, v.status) }}</span>
                         </div>
                     </div>
                     <div class="flex gap-2 mt-2 pt-2 border-t border-gray-100">
@@ -576,7 +576,7 @@ const STATUS_LABELS = {
 };
 
 const STATUS_BADGE_CLASSES = {
-    not_contacted:   'bg-gray-100 text-gray-500',
+    not_contacted:   'bg-gray-200 text-gray-700',
     quote_received:  'bg-blue-100 text-blue-700',
     contract_signed: 'bg-amber-100 text-amber-700',
     deal_closed:     'bg-rose-100 text-rose-700',
@@ -675,7 +675,7 @@ function renderCompareView() {
                                         <span class="font-bold text-gray-900 text-sm leading-tight">${escHtml(v.name)}</span>
                                         ${isChosen ? '<span class="text-xs bg-rose-600 text-white px-2 py-0.5 rounded-full font-medium">✓ נבחר</span>' : ''}
                                         ${v.price_quoted ? `<span class="font-bold text-sm ${minPrice && v.price_quoted === minPrice && catVendors.length > 1 ? 'text-green-600' : 'text-gray-700'}" dir="ltr">₪${v.price_quoted.toLocaleString()}</span>` : '<span class="text-gray-500 text-xs">ללא מחיר</span>'}
-                                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE_CLASSES[v.status] || 'bg-gray-100 text-gray-500'}">${STATUS_LABELS[v.status] || v.status}</span>
+                                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE_CLASSES[v.status] || 'bg-gray-200 text-gray-700'}">${STATUS_LABELS[v.status] || v.status}</span>
                                     </div>
                                 </th>`;
                             }).join('')}
@@ -755,7 +755,7 @@ function renderCompareView() {
                     </div>
                     <div class="flex items-center gap-2 flex-wrap">
                         ${v.price_quoted ? `<span class="text-sm font-bold text-gray-700" dir="ltr">₪${v.price_quoted.toLocaleString()}</span>` : ''}
-                        <span class="text-xs px-2 py-0.5 rounded-full ${STATUS_BADGE_CLASSES[v.status] || 'bg-gray-100 text-gray-500'}">${STATUS_LABELS[v.status] || ''}</span>
+                        <span class="text-xs px-2 py-0.5 rounded-full ${STATUS_BADGE_CLASSES[v.status] || 'bg-gray-200 text-gray-700'}">${STATUS_LABELS[v.status] || ''}</span>
                         <a href="/wedding/vendors/${v.id}" class="text-xs text-rose-600 hover:text-rose-800 font-medium px-2 py-1 rounded-lg hover:bg-rose-50">פרטים</a>
                         <button data-vendor='${jsonAttr(v)}' onclick="openEditModal(JSON.parse(this.dataset.vendor))"
                                 class="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded-lg hover:bg-gray-100">ערוך</button>


### PR DESCRIPTION
## Summary
This PR improves the visual hierarchy and accessibility of the vendor management interface by enhancing contrast ratios for form labels and status badges throughout the wedding vendor pages.

## Key Changes
- **Form labels**: Updated all form field labels from `text-gray-500` to `text-gray-700` for better readability and contrast against white backgrounds
- **"Not contacted" status badge**: Changed from `bg-gray-100 text-gray-600` to `bg-gray-200 text-gray-700` to improve visibility and distinguish it from other status states
- **Secondary text colors**: Updated various secondary text elements from `text-gray-400` to `text-gray-500` or `text-gray-600` for improved contrast
- **Quote totals section**: Enhanced text color from `text-gray-500` to `text-gray-600` for better readability

## Files Modified
- `app/frontend/templates/wedding/vendor_detail.html`: Updated 20+ instances of color classes for labels, status badges, and secondary text
- `app/frontend/templates/wedding/vendors.html`: Updated 10+ instances of color classes for consistency across the vendors list view

## Implementation Details
All changes use existing Tailwind CSS color utilities. The updates maintain the overall design system while improving WCAG contrast compliance for better accessibility.

https://claude.ai/code/session_01RN2we2iQYkpPB5L8Q4K7Gn