### PR TITLE
Gamify the workout page with XP, levels, achievements and quest stages

### DIFF
--- a/app/backend/app/routes/workouts.py
+++ b/app/backend/app/routes/workouts.py
@@ -1,5 +1,6 @@
 import sqlite3
 import logging
+from datetime import date as date_cls, timedelta
 from typing import Dict, List, Any
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -168,25 +169,176 @@ SKILL_PROGRESSIONS = {
     }
 }
 
-@router.get("/workouts", response_class=HTMLResponse)
-async def workout_page(
-    request: Request,
-    db_conn: sqlite3.Connection = Depends(get_db_conn)
-) -> HTMLResponse:
-    """Render the main workout tracker page with active UI and history of workouts."""
-    # Resolve the logged-in user to fetch their workouts only
-    user_obj = request.session.get("user")
+# ====================== GAMIFICATION ENGINE ======================
+# XP is derived deterministically from workout history, so no schema change
+# is needed — every saved workout "earns" points retroactively as well.
+
+XP_BASE_PER_WORKOUT = 50   # showing up is most of the battle
+XP_PER_SET = 10
+XP_PER_REP = 1
+XP_PER_MINUTE = 2
+XP_MINUTES_CAP = 120       # don't reward leaving the timer running overnight
+
+# Rank titles unlocked by level (level -> title)
+RANKS = [
+    (1, "טירון ברזל", "fa-seedling"),
+    (3, "חניך מתאמן", "fa-user-ninja"),
+    (5, "לוחם רחוב", "fa-hand-fist"),
+    (8, "לוחם מתקדם", "fa-shield-halved"),
+    (12, "אלוף השכונה", "fa-medal"),
+    (16, "מאסטר קליסטניקס", "fa-trophy"),
+    (20, "אגדה חיה", "fa-crown"),
+]
+
+
+def _session_xp(total_sets: int, total_reps: int, duration_minutes: int) -> int:
+    """XP earned by a single workout session."""
+    return (
+        XP_BASE_PER_WORKOUT
+        + XP_PER_SET * max(0, total_sets)
+        + XP_PER_REP * max(0, total_reps)
+        + XP_PER_MINUTE * min(max(0, duration_minutes), XP_MINUTES_CAP)
+    )
+
+
+def _xp_needed_for_level(level: int) -> int:
+    """XP needed to advance FROM the given level to the next one."""
+    return 100 + (level - 1) * 75
+
+
+def _level_from_xp(total_xp: int) -> Dict[str, int]:
+    """Convert total XP into level + progress inside the current level."""
+    level = 1
+    remaining = total_xp
+    while remaining >= _xp_needed_for_level(level):
+        remaining -= _xp_needed_for_level(level)
+        level += 1
+    needed = _xp_needed_for_level(level)
+    return {
+        "level": level,
+        "xp_in_level": remaining,
+        "xp_for_next": needed,
+        "progress_pct": min(100, round(remaining * 100 / needed)),
+    }
+
+
+def _rank_for_level(level: int) -> Dict[str, str]:
+    title, icon = RANKS[0][1], RANKS[0][2]
+    for min_level, rank_title, rank_icon in RANKS:
+        if level >= min_level:
+            title, icon = rank_title, rank_icon
+    return {"title": title, "icon": icon}
+
+
+def _next_rank_for_level(level: int) -> Dict[str, Any]:
+    for min_level, rank_title, _ in RANKS:
+        if level < min_level:
+            return {"title": rank_title, "level": min_level}
+    return {}
+
+
+def _compute_streak(dates: List[str]) -> int:
+    """Longest run of consecutive workout days ending at the most recent workout."""
+    day_set = set()
+    for d in dates:
+        try:
+            day_set.add(date_cls.fromisoformat(d[:10]))
+        except (ValueError, TypeError):
+            continue
+    if not day_set:
+        return 0
+    streak = 1
+    day = max(day_set)
+    while day - timedelta(days=1) in day_set:
+        streak += 1
+        day -= timedelta(days=1)
+    return streak
+
+
+def compute_gamification(history: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate workout history into the full player-profile game state."""
+    total_workouts = len(history)
+    total_sets = 0
+    total_reps = 0
+    total_minutes = 0
+    total_xp = 0
+    longest_session = 0
+    max_exercises_in_session = 0
+
+    for session in history:
+        session_sets = sum(ex["sets"] for ex in session["exercises"])
+        session_reps = sum(ex["reps"] for ex in session["exercises"])
+        duration = session.get("total_duration") or 0
+        total_sets += session_sets
+        total_reps += session_reps
+        total_minutes += duration
+        longest_session = max(longest_session, duration)
+        max_exercises_in_session = max(max_exercises_in_session, len(session["exercises"]))
+        total_xp += _session_xp(session_sets, session_reps, duration)
+
+    streak = _compute_streak([s["date"] for s in history])
+    level_info = _level_from_xp(total_xp)
+    level = level_info["level"]
+
+    achievement_defs = [
+        ("first_steps", "fa-shoe-prints", "צעד ראשון", "השלם אימון ראשון", total_workouts, 1),
+        ("warming_up", "fa-fire", "מתחמם", "השלם 5 אימונים", total_workouts, 5),
+        ("iron_addict", "fa-dumbbell", "מכור לברזל", "השלם 15 אימונים", total_workouts, 15),
+        ("local_legend", "fa-crown", "אגדה מקומית", "השלם 50 אימונים", total_workouts, 50),
+        ("set_collector", "fa-layer-group", "אספן סטים", "בצע 100 סטים במצטבר", total_sets, 100),
+        ("set_machine", "fa-industry", "מכונת סטים", "בצע 500 סטים במצטבר", total_sets, 500),
+        ("rep_1000", "fa-bolt", "אלף חזרות", "בצע 1,000 חזרות במצטבר", total_reps, 1000),
+        ("rep_5000", "fa-meteor", "5,000 חזרות", "בצע 5,000 חזרות במצטבר", total_reps, 5000),
+        ("streak_3", "fa-fire-flame-curved", "על הגל", "3 ימי אימון ברצף", streak, 3),
+        ("streak_7", "fa-calendar-week", "שבוע מושלם", "7 ימי אימון ברצף", streak, 7),
+        ("marathon", "fa-stopwatch", "מרתוניסט", "אימון של 60 דקות ומעלה", longest_session, 60),
+        ("variety", "fa-shapes", "מגוון אישי", "5 תרגילים שונים באימון אחד", max_exercises_in_session, 5),
+    ]
+    achievements = [
+        {
+            "id": a_id,
+            "icon": icon,
+            "title": title,
+            "desc": desc,
+            "current": min(current, target),
+            "target": target,
+            "unlocked": current >= target,
+        }
+        for a_id, icon, title, desc, current, target in achievement_defs
+    ]
+
+    return {
+        "total_xp": total_xp,
+        "level": level,
+        "xp_in_level": level_info["xp_in_level"],
+        "xp_for_next": level_info["xp_for_next"],
+        "progress_pct": level_info["progress_pct"],
+        "rank": _rank_for_level(level),
+        "next_rank": _next_rank_for_level(level),
+        "streak": streak,
+        "total_workouts": total_workouts,
+        "total_sets": total_sets,
+        "total_reps": total_reps,
+        "total_minutes": total_minutes,
+        "achievements": achievements,
+        "unlocked_count": sum(1 for a in achievements if a["unlocked"]),
+    }
+
+
+def _resolve_user_id(request: Request, db_conn: sqlite3.Connection):
+    """Resolve logged-in user id, or None when auth is enabled and no session."""
     import os
+    user_obj = request.session.get("user")
     auth_enabled = os.environ.get("AUTH_ENABLED", "1") == "1"
     if not user_obj and auth_enabled:
-        # AuthMiddleware will redirect, but as defensive fallback
-        return HTMLResponse("Unauthorized", status_code=status.HTTP_401_UNAUTHORIZED)
-        
+        return None
     username = (user_obj.get("username") if user_obj else "Yosef").title()
     user_row = db_conn.execute("SELECT id FROM users WHERE name = ?", (username,)).fetchone()
-    user_id = user_row["id"] if user_row else 1
+    return user_row["id"] if user_row else 1
 
-    # Fetch workout logs from the database
+
+def _fetch_history(db_conn: sqlite3.Connection, user_id: int) -> List[Dict[str, Any]]:
+    """Fetch workout rows and aggregate them into per-session dicts."""
     rows = db_conn.execute(
         """
         SELECT date, workout_type, total_duration, exercise_name, total_sets, total_reps
@@ -197,7 +349,6 @@ async def workout_page(
         (user_id,)
     ).fetchall()
 
-    # Aggregate exercises by workout session (grouped by date, type, and duration)
     workout_sessions = {}
     for r in rows:
         session_key = (r["date"], r["workout_type"], r["total_duration"])
@@ -213,8 +364,22 @@ async def workout_page(
             "sets": r["total_sets"],
             "reps": r["total_reps"]
         })
-        
-    history = list(workout_sessions.values())
+    return list(workout_sessions.values())
+
+
+@router.get("/workouts", response_class=HTMLResponse)
+async def workout_page(
+    request: Request,
+    db_conn: sqlite3.Connection = Depends(get_db_conn)
+) -> HTMLResponse:
+    """Render the main workout tracker page with active UI and history of workouts."""
+    user_id = _resolve_user_id(request, db_conn)
+    if user_id is None:
+        # AuthMiddleware will redirect, but as defensive fallback
+        return HTMLResponse("Unauthorized", status_code=status.HTTP_401_UNAUTHORIZED)
+
+    history = _fetch_history(db_conn, user_id)
+    game = compute_gamification(history)
 
     return templates.TemplateResponse(
         "pages/workout.html",
@@ -223,6 +388,7 @@ async def workout_page(
             "default_exercises": DEFAULT_EXERCISES,
             "history": history,
             "skills_guide": SKILL_PROGRESSIONS,
+            "game": game,
             "show_sidebar": False,  # Hide standard finance sidebar to give space for mobile-first workout UI
         }
     )
@@ -234,21 +400,18 @@ async def save_workout(
     request: Request,
     db_conn: sqlite3.Connection = Depends(get_db_conn)
 ):
-    """Save aggregate workout data to the database."""
-    user_obj = request.session.get("user")
-    import os
-    auth_enabled = os.environ.get("AUTH_ENABLED", "1") == "1"
-    if not user_obj and auth_enabled:
+    """Save aggregate workout data and return the game rewards it earned."""
+    user_id = _resolve_user_id(request, db_conn)
+    if user_id is None:
         return JSONResponse({"status": "error", "message": "Not authenticated"}, status_code=status.HTTP_401_UNAUTHORIZED)
-
-    username = (user_obj.get("username") if user_obj else "Yosef").title()
-    user_row = db_conn.execute("SELECT id FROM users WHERE name = ?", (username,)).fetchone()
-    user_id = user_row["id"] if user_row else 1
 
     if not payload.exercises:
         return JSONResponse({"status": "error", "message": "No exercises performed in this workout."}, status_code=status.HTTP_400_BAD_REQUEST)
 
     try:
+        # Snapshot game state before saving to detect level-ups and new badges
+        game_before = compute_gamification(_fetch_history(db_conn, user_id))
+
         # Insert each exercise row
         for ex in payload.exercises:
             if ex.total_sets > 0:
@@ -268,7 +431,32 @@ async def save_workout(
                     )
                 )
         db_conn.commit()
-        return {"status": "success", "message": "Workout saved successfully!"}
+
+        game_after = compute_gamification(_fetch_history(db_conn, user_id))
+        unlocked_before = {a["id"] for a in game_before["achievements"] if a["unlocked"]}
+        new_achievements = [
+            {"icon": a["icon"], "title": a["title"], "desc": a["desc"]}
+            for a in game_after["achievements"]
+            if a["unlocked"] and a["id"] not in unlocked_before
+        ]
+
+        return {
+            "status": "success",
+            "message": "Workout saved successfully!",
+            "rewards": {
+                "xp_gained": game_after["total_xp"] - game_before["total_xp"],
+                "total_xp": game_after["total_xp"],
+                "old_level": game_before["level"],
+                "new_level": game_after["level"],
+                "leveled_up": game_after["level"] > game_before["level"],
+                "rank": game_after["rank"],
+                "xp_in_level": game_after["xp_in_level"],
+                "xp_for_next": game_after["xp_for_next"],
+                "progress_pct": game_after["progress_pct"],
+                "streak": game_after["streak"],
+                "new_achievements": new_achievements,
+            },
+        }
     except Exception as e:
         logger.exception("Failed to save workout session")
         return JSONResponse({"status": "error", "message": f"Database error: {str(e)}"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/app/frontend/static/js/workout.js
+++ b/app/frontend/static/js/workout.js
@@ -10,6 +10,11 @@ let restTimerInterval = null;
 let restTimeRemaining = 0;
 let isTimerFinished = false;
 
+// --- Gamification State ---
+// Mirrors the server XP formula: every completed set is worth 10 XP + 1 XP per rep.
+const XP_PER_SET = 10;
+let comboCount = 0; // consecutive completed sets without unchecking
+
 // --- Initialize Page ---
 document.addEventListener('DOMContentLoaded', () => {
     // 1. Set default date to today in local timezone
@@ -27,18 +32,26 @@ document.addEventListener('DOMContentLoaded', () => {
     if (select) {
         displaySkillData(select.value);
     }
+
+    // 3. Paint quest stage maps (locked/current/conquered) from saved progress
+    renderAllStageMaps();
 });
 
 // --- Start Workout Session (User triggered) ---
 function startWorkoutSession() {
     workoutStartTime = Date.now();
-    
+
     const startContainer = document.getElementById('start-session-container');
     const sessionContainer = document.getElementById('active-workout-session');
-    
+
     if (startContainer) startContainer.classList.add('hidden');
     if (sessionContainer) sessionContainer.classList.remove('hidden');
-    
+
+    // Reset game HUD for the fresh session
+    comboCount = 0;
+    updateSessionScore();
+    updateComboIndicator();
+
     startWorkoutTimer();
 }
 
@@ -298,10 +311,71 @@ function toggleSetDone(exerciseId, setId, isChecked) {
         }
     }
 
+    // --- Game feedback: XP + combo ---
+    if (isChecked) {
+        comboCount++;
+        spawnXpFloat(rowEl, XP_PER_SET + set.reps);
+        if (navigator.vibrate) navigator.vibrate(40);
+    } else {
+        comboCount = 0; // breaking the chain resets the combo
+    }
+    updateSessionScore();
+    updateComboIndicator();
+
     // Trigger Sticky Rest Timer countdown if checked "Done"
     if (isChecked) {
         startRestTimer(set.rest);
     }
+}
+
+// --- Session Score HUD ---
+function computeSessionScore() {
+    let score = 0;
+    activeExercises.forEach(ex => {
+        ex.sets.forEach(set => {
+            if (set.done) score += XP_PER_SET + set.reps;
+        });
+    });
+    return score;
+}
+
+function updateSessionScore() {
+    const scoreEl = document.getElementById('session-score');
+    if (!scoreEl) return;
+    scoreEl.textContent = computeSessionScore();
+    scoreEl.classList.remove('score-bump');
+    void scoreEl.offsetWidth; // restart the CSS animation
+    scoreEl.classList.add('score-bump');
+}
+
+function updateComboIndicator() {
+    const indicator = document.getElementById('combo-indicator');
+    const countEl = document.getElementById('combo-count');
+    if (!indicator || !countEl) return;
+
+    if (comboCount >= 2) {
+        countEl.textContent = comboCount;
+        indicator.classList.remove('hidden');
+        indicator.classList.remove('combo-pop');
+        void indicator.offsetWidth;
+        indicator.classList.add('combo-pop');
+    } else {
+        indicator.classList.add('hidden');
+    }
+}
+
+// Floating "+XP" particle rising from the completed set row.
+// Pass a number for XP, or any string for a custom celebration text.
+function spawnXpFloat(anchorEl, xp) {
+    if (!anchorEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    const float = document.createElement('div');
+    float.className = 'xp-float text-lg';
+    float.textContent = typeof xp === 'number' ? `+${xp} XP` : xp;
+    float.style.left = `${rect.left + rect.width / 2 - 30}px`;
+    float.style.top = `${rect.top}px`;
+    document.body.appendChild(float);
+    setTimeout(() => float.remove(), 1300);
 }
 
 // --- Sticky Rest Timer countdown Logic ---
@@ -473,12 +547,10 @@ async function finishWorkout() {
         if (response.ok && data.status === 'success') {
             // Success animation/feedback
             if (navigator.vibrate) {
-                navigator.vibrate(300);
+                navigator.vibrate([100, 50, 100, 50, 300]);
             }
-            alert("האימון נשמר בהצלחה!");
-            
-            // Reload page to update history and clear state
-            window.location.reload();
+            // Game-style victory screen with rewards from the server
+            showVictoryModal(data.rewards, totalCompletedSets);
         } else {
             alert(`שגיאה בשמירת האימון: ${data.message || 'שגיאה כללית בשרת'}`);
         }
@@ -489,35 +561,24 @@ async function finishWorkout() {
 }
 
 // --- Interactive Skill Progressions Guide Logic ---
+const SIDEBAR_TABS = ['history', 'skills', 'achievements'];
+
 function switchSidebarTab(tabName) {
-    const tabHistory = document.getElementById('tab-history');
-    const tabSkills = document.getElementById('tab-skills');
-    const historyContent = document.getElementById('sidebar-history-content');
-    const skillsContent = document.getElementById('sidebar-skills-content');
-    
-    if (tabName === 'history') {
-        if (tabHistory) {
-            tabHistory.classList.add('border-indigo-600', 'text-indigo-600');
-            tabHistory.classList.remove('border-transparent', 'text-gray-500');
+    SIDEBAR_TABS.forEach(name => {
+        const tabBtn = document.getElementById(`tab-${name}`);
+        const content = document.getElementById(`sidebar-${name}-content`);
+        const isActive = name === tabName;
+
+        if (tabBtn) {
+            tabBtn.classList.toggle('border-indigo-600', isActive);
+            tabBtn.classList.toggle('text-indigo-600', isActive);
+            tabBtn.classList.toggle('border-transparent', !isActive);
+            tabBtn.classList.toggle('text-gray-500', !isActive);
         }
-        if (tabSkills) {
-            tabSkills.classList.remove('border-indigo-600', 'text-indigo-600');
-            tabSkills.classList.add('border-transparent', 'text-gray-500');
-        }
-        if (historyContent) historyContent.classList.remove('hidden');
-        if (skillsContent) skillsContent.classList.add('hidden');
-    } else {
-        if (tabHistory) {
-            tabHistory.classList.remove('border-indigo-600', 'text-indigo-600');
-            tabHistory.classList.add('border-transparent', 'text-gray-500');
-        }
-        if (tabSkills) {
-            tabSkills.classList.add('border-indigo-600', 'text-indigo-600');
-            tabSkills.classList.remove('border-transparent', 'text-gray-500');
-        }
-        if (historyContent) historyContent.classList.add('hidden');
-        if (skillsContent) skillsContent.classList.remove('hidden');
-        
+        if (content) content.classList.toggle('hidden', !isActive);
+    });
+
+    if (tabName === 'skills') {
         // Auto display selected skill details
         const select = document.getElementById('skill-select');
         if (select) {
@@ -548,6 +609,193 @@ function toggleCuesAccordion(skillKey) {
     if (icon) {
         icon.classList.toggle('rotate-180');
     }
+}
+
+// ====================== VICTORY SCREEN & CONFETTI ======================
+
+function animateCountUp(el, target, durationMs) {
+    if (!el) return;
+    const start = performance.now();
+    const step = (now) => {
+        const progress = Math.min((now - start) / durationMs, 1);
+        // ease-out cubic
+        const eased = 1 - Math.pow(1 - progress, 3);
+        el.textContent = Math.round(target * eased);
+        if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+}
+
+function launchConfetti(pieceCount) {
+    const colors = ['#facc15', '#a855f7', '#22c55e', '#3b82f6', '#f97316', '#ec4899'];
+    for (let i = 0; i < pieceCount; i++) {
+        const piece = document.createElement('div');
+        piece.className = 'confetti-piece';
+        const size = 6 + Math.random() * 8;
+        piece.style.left = `${Math.random() * 100}vw`;
+        piece.style.width = `${size}px`;
+        piece.style.height = `${size * (0.4 + Math.random() * 0.8)}px`;
+        piece.style.background = colors[Math.floor(Math.random() * colors.length)];
+        piece.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
+        piece.style.animationDuration = `${2.2 + Math.random() * 2.5}s`;
+        piece.style.animationDelay = `${Math.random() * 0.8}s`;
+        document.body.appendChild(piece);
+        setTimeout(() => piece.remove(), 6000);
+    }
+}
+
+function showVictoryModal(rewards, completedSets) {
+    const modal = document.getElementById('victory-modal');
+    if (!modal || !rewards) {
+        // Fallback if the server didn't send rewards (e.g. older cached response)
+        alert("האימון נשמר בהצלחה!");
+        window.location.reload();
+        return;
+    }
+
+    modal.classList.add('active');
+    launchConfetti(90);
+
+    // Stars: 1 for finishing, 2 for a solid session, 3 for a big one
+    const starCount = completedSets >= 16 ? 3 : (completedSets >= 8 ? 2 : 1);
+    const stars = modal.querySelectorAll('.victory-star');
+    stars.forEach((star, idx) => {
+        star.classList.toggle('earned', idx < starCount);
+    });
+
+    // XP earned count-up
+    animateCountUp(document.getElementById('victory-xp'), rewards.xp_gained, 1400);
+
+    // Level + progress bar toward the next level
+    const levelEl = document.getElementById('victory-level');
+    if (levelEl) levelEl.textContent = rewards.new_level;
+    const xpLabel = document.getElementById('victory-xp-label');
+    if (xpLabel) xpLabel.textContent = `${rewards.xp_in_level} / ${rewards.xp_for_next} XP`;
+    const bar = document.getElementById('victory-xp-bar');
+    if (bar) {
+        // Animate from 0 to the real progress after the card pops in
+        setTimeout(() => { bar.style.width = `${rewards.progress_pct}%`; }, 400);
+    }
+
+    // Level-up banner
+    if (rewards.leveled_up) {
+        const banner = document.getElementById('victory-levelup');
+        const newLevelEl = document.getElementById('victory-new-level');
+        if (newLevelEl) newLevelEl.textContent = rewards.new_level;
+        if (banner) banner.classList.remove('hidden');
+        // Extra celebration for a level-up
+        setTimeout(() => launchConfetti(60), 900);
+    }
+
+    // Newly unlocked achievements
+    if (rewards.new_achievements && rewards.new_achievements.length > 0) {
+        const container = document.getElementById('victory-achievements');
+        if (container) {
+            container.innerHTML = rewards.new_achievements.map(ach => `
+                <div class="flex items-center gap-3 bg-yellow-400/10 border border-yellow-400/30 rounded-xl px-3 py-2.5">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-yellow-400 to-amber-500 text-white flex items-center justify-center flex-shrink-0">
+                        <i class="fas ${ach.icon}"></i>
+                    </div>
+                    <div>
+                        <p class="text-xs font-black text-yellow-300">הישג חדש: ${ach.title}</p>
+                        <p class="text-[10px] text-purple-300">${ach.desc}</p>
+                    </div>
+                </div>
+            `).join('');
+            container.classList.remove('hidden');
+        }
+    }
+}
+
+function closeVictoryModal() {
+    // Reload refreshes the player card, history and achievements with server state
+    window.location.reload();
+}
+
+// ====================== QUEST STAGE MAP (Skill progressions as game levels) ======================
+// Stage completion is personal training progress, persisted locally per browser.
+
+const SKILL_PROGRESS_KEY = 'workout_skill_progress_v1';
+
+function getSkillProgress() {
+    try {
+        return JSON.parse(localStorage.getItem(SKILL_PROGRESS_KEY)) || {};
+    } catch (e) {
+        return {};
+    }
+}
+
+function saveSkillProgress(progress) {
+    try {
+        localStorage.setItem(SKILL_PROGRESS_KEY, JSON.stringify(progress));
+    } catch (e) { /* private mode — progress just won't persist */ }
+}
+
+function toggleStageComplete(skillKey, stageIdx) {
+    const progress = getSkillProgress();
+    const completed = new Set(progress[skillKey] || []);
+
+    if (completed.has(stageIdx)) {
+        completed.delete(stageIdx);
+    } else {
+        completed.add(stageIdx);
+        // Small celebration for conquering a stage
+        const node = document.getElementById(`stage-${skillKey}-${stageIdx}`);
+        spawnXpFloat(node, '⭐');
+        if (navigator.vibrate) navigator.vibrate([60, 40, 60]);
+        launchConfetti(25);
+    }
+
+    progress[skillKey] = Array.from(completed).sort((a, b) => a - b);
+    saveSkillProgress(progress);
+    renderStageMap(skillKey);
+}
+
+function renderStageMap(skillKey) {
+    const nodes = document.querySelectorAll(`.stage-node[data-skill="${skillKey}"]`);
+    if (!nodes.length) return;
+
+    const completed = new Set(getSkillProgress()[skillKey] || []);
+    // The "current" stage is the first uncompleted one
+    let currentIdx = 0;
+    while (completed.has(currentIdx)) currentIdx++;
+
+    nodes.forEach(node => {
+        const idx = parseInt(node.dataset.stage, 10);
+        const isDone = completed.has(idx);
+        const isCurrent = idx === currentIdx;
+
+        node.classList.toggle('stage-completed', isDone);
+        node.classList.toggle('stage-current', isCurrent);
+        node.classList.toggle('stage-locked', !isDone && !isCurrent);
+
+        const dotLabel = node.querySelector('.stage-dot-label');
+        if (dotLabel) {
+            dotLabel.innerHTML = isDone ? '<i class="fas fa-check"></i>'
+                : (!isCurrent ? '<i class="fas fa-lock text-[8px]"></i>' : `${idx + 1}`);
+        }
+        const statusIcon = node.querySelector('.stage-status-icon');
+        if (statusIcon) {
+            statusIcon.innerHTML = isDone ? '<i class="fas fa-star text-yellow-500 text-[10px]"></i>'
+                : (isCurrent ? '<i class="fas fa-location-arrow text-purple-500 text-[10px]"></i>' : '');
+        }
+        const conquerLabel = node.querySelector('.stage-conquer-label');
+        if (conquerLabel) conquerLabel.textContent = isDone ? 'בטל' : 'כבשתי!';
+    });
+
+    // Quest progress bar + counter
+    const total = nodes.length;
+    const doneCount = Math.min(completed.size, total);
+    const bar = document.getElementById(`quest-bar-${skillKey}`);
+    if (bar) bar.style.width = `${Math.round(doneCount * 100 / total)}%`;
+    const counter = document.getElementById(`quest-progress-${skillKey}`);
+    if (counter) counter.textContent = `${doneCount}/${total} שלבים`;
+}
+
+function renderAllStageMaps() {
+    const skillKeys = new Set();
+    document.querySelectorAll('.stage-node[data-skill]').forEach(node => skillKeys.add(node.dataset.skill));
+    skillKeys.forEach(key => renderStageMap(key));
 }
 
 function addSkillProgression(name, hebrew, reps, rest) {

--- a/app/frontend/templates/pages/workout.html
+++ b/app/frontend/templates/pages/workout.html
@@ -81,6 +81,123 @@
     #rest-timer-banner {
         padding-bottom: max(1rem, calc(0.5rem + env(safe-area-inset-bottom, 0px)));
     }
+
+    /* ===== GAMIFICATION ===== */
+    /* XP bar animated shine sweep */
+    .xp-bar-fill {
+        position: relative;
+        overflow: hidden;
+        transition: width 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .xp-bar-fill::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(105deg, transparent 30%, rgba(255,255,255,0.45) 50%, transparent 70%);
+        animation: xp-shine 2.5s ease-in-out infinite;
+    }
+    @keyframes xp-shine {
+        0% { transform: translateX(100%); }
+        60%, 100% { transform: translateX(-100%); }
+    }
+    /* Level badge glow */
+    .level-badge {
+        box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.25), 0 0 20px rgba(250, 204, 21, 0.4);
+    }
+    /* Floating +XP particle rising from a completed set */
+    .xp-float {
+        position: fixed;
+        z-index: 900;
+        pointer-events: none;
+        font-weight: 900;
+        color: #16a34a;
+        text-shadow: 0 1px 3px rgba(255,255,255,0.9);
+        animation: xp-float-up 1.2s ease-out forwards;
+    }
+    @keyframes xp-float-up {
+        0% { opacity: 0; transform: translateY(0) scale(0.6); }
+        15% { opacity: 1; transform: translateY(-10px) scale(1.15); }
+        100% { opacity: 0; transform: translateY(-70px) scale(1); }
+    }
+    /* Combo flame pop */
+    .combo-pop {
+        animation: combo-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+    @keyframes combo-pop {
+        0% { transform: scale(1); }
+        50% { transform: scale(1.35); }
+        100% { transform: scale(1); }
+    }
+    /* Session score bump */
+    .score-bump {
+        animation: score-bump 0.35s ease-out;
+    }
+    @keyframes score-bump {
+        0% { transform: scale(1); color: #facc15; }
+        50% { transform: scale(1.25); color: #fde047; }
+        100% { transform: scale(1); }
+    }
+    /* Victory modal entrance */
+    #victory-modal.active { display: flex; }
+    #victory-modal { display: none; }
+    .victory-card {
+        animation: victory-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+    @keyframes victory-in {
+        0% { opacity: 0; transform: scale(0.7) translateY(40px); }
+        100% { opacity: 1; transform: scale(1) translateY(0); }
+    }
+    /* Victory stars staggered pop */
+    .victory-star { opacity: 0; transform: scale(0); }
+    .victory-star.earned {
+        animation: star-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    }
+    @keyframes star-pop {
+        0% { opacity: 0; transform: scale(0) rotate(-40deg); }
+        70% { opacity: 1; transform: scale(1.3) rotate(8deg); }
+        100% { opacity: 1; transform: scale(1) rotate(0); }
+    }
+    /* Level-up banner pulse */
+    .levelup-banner {
+        animation: levelup-glow 1.2s ease-in-out infinite alternate;
+    }
+    @keyframes levelup-glow {
+        from { box-shadow: 0 0 12px rgba(250, 204, 21, 0.5); }
+        to { box-shadow: 0 0 32px rgba(250, 204, 21, 0.95); }
+    }
+    /* Confetti pieces */
+    .confetti-piece {
+        position: fixed;
+        top: -20px;
+        z-index: 950;
+        pointer-events: none;
+        animation: confetti-fall linear forwards;
+    }
+    @keyframes confetti-fall {
+        0% { transform: translateY(0) rotate(0deg); opacity: 1; }
+        100% { transform: translateY(105vh) rotate(720deg); opacity: 0.4; }
+    }
+    /* Achievement badges */
+    .achievement-locked {
+        filter: grayscale(1);
+        opacity: 0.45;
+    }
+    /* Quest stage map states */
+    .stage-node { transition: all 0.25s ease; }
+    .stage-completed .stage-dot { background: #22c55e; border-color: #86efac; }
+    .stage-current .stage-dot {
+        background: #a855f7;
+        border-color: #e9d5ff;
+        animation: stage-pulse 1.6s ease-in-out infinite;
+    }
+    .stage-locked { opacity: 0.55; }
+    .stage-locked .stage-dot { background: #d1d5db; border-color: #e5e7eb; }
+    .stage-current .stage-card { border-color: #c084fc; box-shadow: 0 4px 14px -4px rgba(168, 85, 247, 0.35); }
+    .stage-completed .stage-card { background: #f0fdf4; border-color: #bbf7d0; }
+    @keyframes stage-pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.5); }
+        50% { box-shadow: 0 0 0 6px rgba(168, 85, 247, 0); }
+    }
 </style>
 {% endblock %}
 
@@ -94,7 +211,62 @@
                 <i class="fas fa-dumbbell text-purple-600"></i>
                 מעקב אימוני קליסטניקס
             </h1>
-            <p class="text-sm text-gray-600 mt-1">נהל את האימונים שלך, עקוב אחר זמני מנוחה ושמור סיכומים ישירות למסד הנתונים.</p>
+            <p class="text-sm text-gray-600 mt-1">כל סט שווה נקודות. תתאמן, תצבור XP, תעלה שלב ותפתח הישגים.</p>
+        </div>
+    </div>
+
+    <!-- ===== PLAYER CARD (Gamification profile) ===== -->
+    <div class="mb-8 bg-gradient-to-l from-gray-900 via-purple-950 to-indigo-950 rounded-2xl border border-purple-800/40 shadow-xl p-5 sm:p-6 text-white relative overflow-hidden">
+        <!-- Decorative glow -->
+        <div class="absolute -top-16 -left-16 w-48 h-48 bg-purple-600/20 rounded-full blur-3xl pointer-events-none"></div>
+
+        <div class="flex flex-col sm:flex-row sm:items-center gap-5 relative">
+            <!-- Level badge -->
+            <div class="flex items-center gap-4 flex-shrink-0">
+                <div class="level-badge w-20 h-20 rounded-2xl bg-gradient-to-br from-yellow-400 to-amber-600 flex flex-col items-center justify-center text-gray-900 flex-shrink-0">
+                    <span class="text-[10px] font-black uppercase tracking-wider leading-none">שלב</span>
+                    <span id="player-level" class="text-3xl font-black leading-none digital-timer">{{ game.level }}</span>
+                </div>
+                <div>
+                    <div class="flex items-center gap-2">
+                        <i class="fas {{ game.rank.icon }} text-yellow-400"></i>
+                        <h2 class="text-lg font-black">{{ game.rank.title }}</h2>
+                    </div>
+                    {% if game.next_rank %}
+                    <p class="text-[11px] text-purple-300 mt-0.5">הדרגה הבאה: {{ game.next_rank.title }} (שלב {{ game.next_rank.level }})</p>
+                    {% else %}
+                    <p class="text-[11px] text-yellow-300 mt-0.5"><i class="fas fa-crown"></i> הגעת לדרגה הגבוהה ביותר!</p>
+                    {% endif %}
+                    <!-- Streak flame -->
+                    <div class="mt-1.5 inline-flex items-center gap-1.5 px-2.5 py-1 bg-orange-500/20 border border-orange-400/30 rounded-full text-xs font-bold text-orange-300">
+                        <i class="fas fa-fire {{ 'animate-pulse' if game.streak >= 3 else '' }}"></i>
+                        רצף: {{ game.streak }} {{ 'ימים' if game.streak != 1 else 'יום' }}
+                    </div>
+                </div>
+            </div>
+
+            <!-- XP progress -->
+            <div class="flex-1 min-w-0">
+                <div class="flex justify-between items-baseline mb-1.5 text-xs">
+                    <span class="font-bold text-purple-200">
+                        <i class="fas fa-star text-yellow-400 ml-1"></i>
+                        <span id="player-total-xp">{{ "{:,}".format(game.total_xp) }}</span> XP סה"כ
+                    </span>
+                    <span class="text-purple-300 digital-timer">{{ game.xp_in_level }} / {{ game.xp_for_next }}</span>
+                </div>
+                <div class="h-4 bg-white/10 rounded-full overflow-hidden border border-white/10">
+                    <div id="player-xp-bar" class="xp-bar-fill h-full bg-gradient-to-l from-yellow-400 to-amber-500 rounded-full" style="width: {{ game.progress_pct }}%;"></div>
+                </div>
+                <p class="text-[11px] text-purple-300 mt-1.5">עוד <span class="font-bold text-white">{{ game.xp_for_next - game.xp_in_level }} XP</span> לשלב {{ game.level + 1 }} 🚀</p>
+
+                <!-- Career stats chips -->
+                <div class="flex flex-wrap gap-2 mt-3">
+                    <span class="px-2.5 py-1 bg-white/10 rounded-lg text-[11px] font-bold"><i class="fas fa-dumbbell text-purple-300 ml-1"></i>{{ game.total_workouts }} אימונים</span>
+                    <span class="px-2.5 py-1 bg-white/10 rounded-lg text-[11px] font-bold"><i class="fas fa-layer-group text-purple-300 ml-1"></i>{{ game.total_sets }} סטים</span>
+                    <span class="px-2.5 py-1 bg-white/10 rounded-lg text-[11px] font-bold"><i class="fas fa-bolt text-purple-300 ml-1"></i>{{ "{:,}".format(game.total_reps) }} חזרות</span>
+                    <span class="px-2.5 py-1 bg-white/10 rounded-lg text-[11px] font-bold"><i class="fas fa-medal text-yellow-400 ml-1"></i>{{ game.unlocked_count }}/{{ game.achievements|length }} הישגים</span>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -120,14 +292,28 @@
             <div id="active-workout-session" class="hidden bg-white rounded-2xl border border-gray-200 shadow-xl overflow-hidden">
                 <!-- Session Controller Header -->
                 <div class="bg-gradient-to-l from-purple-800 to-indigo-900 p-4 sm:p-6 text-white">
-                    <!-- Row 1: Timer -->
-                    <div class="flex items-center gap-3 mb-4">
-                        <div class="w-11 h-11 bg-white/10 rounded-xl flex items-center justify-center text-xl shadow-inner animate-pulse flex-shrink-0">
-                            <i class="fas fa-stopwatch text-purple-300"></i>
+                    <!-- Row 1: Timer + Session Score HUD -->
+                    <div class="flex items-center justify-between gap-3 mb-4">
+                        <div class="flex items-center gap-3">
+                            <div class="w-11 h-11 bg-white/10 rounded-xl flex items-center justify-center text-xl shadow-inner animate-pulse flex-shrink-0">
+                                <i class="fas fa-stopwatch text-purple-300"></i>
+                            </div>
+                            <div>
+                                <span class="text-xs text-purple-200 uppercase tracking-wider font-semibold">משך זמן האימון</span>
+                                <div id="workout-timer" class="text-3xl font-black digital-timer text-white leading-none">00:00</div>
+                            </div>
                         </div>
-                        <div>
-                            <span class="text-xs text-purple-200 uppercase tracking-wider font-semibold">משך זמן האימון</span>
-                            <div id="workout-timer" class="text-3xl font-black digital-timer text-white leading-none">00:00</div>
+                        <!-- Live game HUD -->
+                        <div class="text-left flex-shrink-0">
+                            <div class="flex items-center justify-end gap-1.5">
+                                <span id="session-score" class="text-3xl font-black digital-timer text-yellow-400 leading-none">0</span>
+                                <i class="fas fa-star text-yellow-400 text-sm"></i>
+                            </div>
+                            <span class="text-xs text-purple-200 uppercase tracking-wider font-semibold">XP באימון</span>
+                            <div id="combo-indicator" class="hidden mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-orange-500/30 border border-orange-400/40 rounded-full text-[11px] font-black text-orange-300">
+                                <i class="fas fa-fire"></i>
+                                קומבו x<span id="combo-count">0</span>
+                            </div>
                         </div>
                     </div>
                     <!-- Row 2: Workout details — full width inputs on mobile -->
@@ -194,15 +380,20 @@
             <div class="bg-white rounded-2xl border border-gray-200 shadow-md p-6">
                 <!-- Tabs Selector -->
                 <div class="flex border-b border-gray-200 mb-4">
-                    <button id="tab-history" onclick="switchSidebarTab('history')" 
+                    <button id="tab-history" onclick="switchSidebarTab('history')"
                             class="flex-1 pb-3 text-sm font-bold border-b-2 border-indigo-600 text-indigo-600 transition-all text-center focus:outline-none">
                         <i class="fas fa-history ml-1.5"></i>
                         היסטוריה
                     </button>
-                    <button id="tab-skills" onclick="switchSidebarTab('skills')" 
+                    <button id="tab-skills" onclick="switchSidebarTab('skills')"
+                            class="flex-1 pb-3 text-sm font-bold border-b-2 border-transparent text-gray-500 hover:text-gray-700 transition-all text-center focus:outline-none">
+                        <i class="fas fa-map ml-1.5"></i>
+                        מסע מיומנויות
+                    </button>
+                    <button id="tab-achievements" onclick="switchSidebarTab('achievements')"
                             class="flex-1 pb-3 text-sm font-bold border-b-2 border-transparent text-gray-500 hover:text-gray-700 transition-all text-center focus:outline-none">
                         <i class="fas fa-medal ml-1.5"></i>
-                        מדריך מיומנויות
+                        הישגים
                     </button>
                 </div>
 
@@ -238,6 +429,37 @@
                             <p class="text-sm">לא נמצאו אימונים קודמים.</p>
                         </div>
                     {% endif %}
+                </div>
+
+                <!-- Tab content: Achievements (Badges) -->
+                <div id="sidebar-achievements-content" class="hidden max-h-[600px] overflow-y-auto pr-1">
+                    <p class="text-xs text-gray-500 mb-4">
+                        <i class="fas fa-medal text-yellow-500 ml-1"></i>
+                        פתחת <span class="font-black text-gray-800">{{ game.unlocked_count }}</span> מתוך {{ game.achievements|length }} הישגים
+                    </p>
+                    <div class="grid grid-cols-2 gap-3">
+                        {% for ach in game.achievements %}
+                        <div class="p-3 rounded-xl border text-center {{ 'bg-gradient-to-b from-yellow-50 to-amber-50 border-yellow-300 shadow-sm' if ach.unlocked else 'bg-gray-50 border-gray-200 achievement-locked' }}">
+                            <div class="w-12 h-12 mx-auto rounded-full flex items-center justify-center text-xl mb-2 {{ 'bg-gradient-to-br from-yellow-400 to-amber-500 text-white shadow-md' if ach.unlocked else 'bg-gray-200 text-gray-400' }}">
+                                <i class="fas {{ ach.icon if ach.unlocked else 'fa-lock' }}"></i>
+                            </div>
+                            <h4 class="text-xs font-black text-gray-800">{{ ach.title }}</h4>
+                            <p class="text-[10px] text-gray-500 mt-0.5 leading-snug">{{ ach.desc }}</p>
+                            {% if ach.unlocked %}
+                            <span class="inline-block mt-1.5 px-2 py-0.5 bg-green-100 text-green-700 text-[9px] font-black rounded-full">
+                                <i class="fas fa-check ml-0.5"></i>הושג!
+                            </span>
+                            {% else %}
+                            <div class="mt-2">
+                                <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                                    <div class="h-full bg-purple-400 rounded-full" style="width: {{ (ach.current * 100 / ach.target)|round|int }}%;"></div>
+                                </div>
+                                <span class="text-[9px] text-gray-400 font-bold">{{ ach.current }} / {{ ach.target }}</span>
+                            </div>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                    </div>
                 </div>
 
                 <!-- Tab content: Skills Progression Guide -->
@@ -289,33 +511,53 @@
                             </div>
                         </div>
 
-                        <!-- Progression Stepper -->
+                        <!-- Quest Stage Map (Progressions as game levels) -->
                         <div class="space-y-3">
-                            <h4 class="text-xs font-bold text-gray-500 pr-1">שלבי התקדמות (Progressions)</h4>
-                            <div class="relative border-r border-gray-200 mr-2 pr-4 space-y-4">
+                            <div class="flex justify-between items-center pr-1">
+                                <h4 class="text-xs font-bold text-gray-500">מפת השלבים במסע</h4>
+                                <span class="text-[10px] font-black text-purple-600 digital-timer" id="quest-progress-{{ skill_key }}"></span>
+                            </div>
+                            <!-- Quest map progress bar -->
+                            <div class="h-2 bg-gray-100 rounded-full overflow-hidden mx-1">
+                                <div id="quest-bar-{{ skill_key }}" class="h-full bg-gradient-to-l from-purple-500 to-indigo-500 rounded-full transition-all duration-700" style="width: 0%;"></div>
+                            </div>
+                            <div class="relative border-r-2 border-gray-200 mr-3 pr-5 space-y-4">
                                 {% for step in skill.progressions %}
-                                <div class="relative">
-                                    <!-- Stepper dot -->
-                                    <div class="absolute right-[-21px] top-1 w-2.5 h-2.5 rounded-full bg-purple-500 border border-white shadow"></div>
-                                    
-                                    <!-- Step card -->
-                                    <div class="p-3 bg-white border border-gray-150 rounded-xl shadow-sm hover:shadow transition-all text-right">
+                                <div id="stage-{{ skill_key }}-{{ loop.index0 }}" class="stage-node relative" data-skill="{{ skill_key }}" data-stage="{{ loop.index0 }}">
+                                    <!-- Stage number dot -->
+                                    <div class="stage-dot absolute right-[-33px] top-2 w-6 h-6 rounded-full bg-gray-300 border-2 border-white shadow flex items-center justify-center text-[10px] font-black text-white">
+                                        <span class="stage-dot-label">{{ loop.index }}</span>
+                                    </div>
+
+                                    <!-- Stage card -->
+                                    <div class="stage-card p-3 bg-white border border-gray-200 rounded-xl shadow-sm transition-all text-right">
                                         <div class="flex justify-between items-start gap-2">
                                             <div>
-                                                <h5 class="text-xs font-bold text-gray-800">{{ step.hebrew }}</h5>
+                                                <h5 class="text-xs font-bold text-gray-800 flex items-center gap-1.5">
+                                                    <span class="stage-status-icon"></span>
+                                                    {{ step.hebrew }}
+                                                </h5>
                                                 <p class="text-[10px] text-gray-400 mt-0.5">{{ step.name }}</p>
                                             </div>
-                                            <span class="px-1.5 py-0.5 text-[9px] bg-gray-100 text-gray-600 rounded">
+                                            <span class="px-1.5 py-0.5 text-[9px] bg-gray-100 text-gray-600 rounded flex-shrink-0">
                                                 {{ step.reps }} חזרות
                                             </span>
                                         </div>
                                         <div class="mt-2.5 pt-2 border-t border-gray-50 flex justify-between items-center text-[10px]">
                                             <span class="text-gray-400">מנוחה: {{ step.rest }} ש'</span>
-                                            <button onclick="addSkillProgression('{{ step.name }}', '{{ step.hebrew }}', {{ step.reps }}, {{ step.rest }})" 
-                                                    class="px-2.5 py-1 bg-purple-100 hover:bg-purple-200 text-purple-700 font-bold rounded-lg transition-all active:scale-95 flex items-center gap-1 focus:outline-none">
-                                                <i class="fas fa-plus text-[8px]"></i>
-                                                אימון
-                                            </button>
+                                            <div class="flex items-center gap-1.5">
+                                                <button onclick="toggleStageComplete('{{ skill_key }}', {{ loop.index0 }})"
+                                                        class="stage-conquer-btn px-2.5 py-1 bg-green-100 hover:bg-green-200 text-green-700 font-bold rounded-lg transition-all active:scale-95 flex items-center gap-1 focus:outline-none"
+                                                        title="סמן שכבשת את השלב">
+                                                    <i class="fas fa-flag-checkered text-[8px]"></i>
+                                                    <span class="stage-conquer-label">כבשתי!</span>
+                                                </button>
+                                                <button onclick="addSkillProgression('{{ step.name }}', '{{ step.hebrew }}', {{ step.reps }}, {{ step.rest }})"
+                                                        class="px-2.5 py-1 bg-purple-100 hover:bg-purple-200 text-purple-700 font-bold rounded-lg transition-all active:scale-95 flex items-center gap-1 focus:outline-none">
+                                                    <i class="fas fa-plus text-[8px]"></i>
+                                                    אימון
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -408,6 +650,59 @@
     </div>
     <!-- Safe area spacer for iPhone X+ home bar -->
     <div style="height: env(safe-area-inset-bottom, 0px);"></div>
+</div>
+
+<!-- ================= VICTORY MODAL (Workout complete rewards) ================= -->
+<div id="victory-modal" class="fixed inset-0 z-[600] bg-gray-950/85 items-center justify-center p-4">
+    <div class="victory-card w-full max-w-md bg-gradient-to-b from-gray-900 via-purple-950 to-indigo-950 border border-purple-700/50 rounded-3xl shadow-2xl p-6 sm:p-8 text-center text-white relative overflow-hidden">
+        <!-- Glow decoration -->
+        <div class="absolute -top-20 left-1/2 -translate-x-1/2 w-64 h-64 bg-yellow-400/10 rounded-full blur-3xl pointer-events-none"></div>
+
+        <!-- Trophy -->
+        <div class="w-20 h-20 mx-auto rounded-full bg-gradient-to-br from-yellow-400 to-amber-600 flex items-center justify-center text-4xl text-white shadow-lg level-badge mb-3 relative">
+            <i class="fas fa-trophy"></i>
+        </div>
+        <h2 class="text-2xl font-black mb-1">אימון הושלם! 🎉</h2>
+        <p class="text-sm text-purple-300 mb-4">כל הכבוד, לוחם. הנקודות נזקפו לזכותך.</p>
+
+        <!-- Stars -->
+        <div class="flex justify-center gap-3 text-4xl mb-5" id="victory-stars">
+            <i class="victory-star fas fa-star text-yellow-400" style="animation-delay: 0.2s;"></i>
+            <i class="victory-star fas fa-star text-yellow-400" style="animation-delay: 0.5s;"></i>
+            <i class="victory-star fas fa-star text-yellow-400" style="animation-delay: 0.8s;"></i>
+        </div>
+
+        <!-- XP earned counter -->
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-4 mb-4">
+            <div class="text-4xl font-black digital-timer text-yellow-400">
+                +<span id="victory-xp">0</span> XP
+            </div>
+            <div class="mt-3">
+                <div class="flex justify-between text-[11px] text-purple-300 mb-1">
+                    <span>שלב <span id="victory-level">1</span></span>
+                    <span id="victory-xp-label"></span>
+                </div>
+                <div class="h-3 bg-white/10 rounded-full overflow-hidden">
+                    <div id="victory-xp-bar" class="xp-bar-fill h-full bg-gradient-to-l from-yellow-400 to-amber-500 rounded-full" style="width: 0%;"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Level up banner (hidden unless leveled up) -->
+        <div id="victory-levelup" class="hidden levelup-banner bg-gradient-to-l from-yellow-500 to-amber-500 text-gray-900 rounded-2xl px-4 py-3 mb-4 font-black text-lg">
+            <i class="fas fa-angles-up ml-1"></i>
+            עלית שלב! ברוך הבא לשלב <span id="victory-new-level"></span>
+        </div>
+
+        <!-- New achievements (hidden unless unlocked) -->
+        <div id="victory-achievements" class="hidden space-y-2 mb-4 text-right"></div>
+
+        <button onclick="closeVictoryModal()"
+                class="w-full py-3.5 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 font-black text-lg rounded-2xl shadow-lg transition-all active:scale-95">
+            <i class="fas fa-check ml-1"></i>
+            מעולה, נתראה באימון הבא!
+        </button>
+    </div>
 </div>
 
 <!-- Scripts -->

--- a/tests/test_workouts_e2e.py
+++ b/tests/test_workouts_e2e.py
@@ -5,8 +5,13 @@ def test_workout_page_loads(app_client):
     r = app_client.get("/workouts")
     assert r.status_code == 200
     assert "היסטוריה" in r.text
-    assert "מדריך מיומנויות" in r.text
+    assert "מסע מיומנויות" in r.text
     assert "exercise-modal" in r.text
+    # Gamification UI elements
+    assert "player-level" in r.text
+    assert "session-score" in r.text
+    assert "victory-modal" in r.text
+    assert "tab-achievements" in r.text
 
 def test_save_workout_success(app_client, db_conn):
     """Test that saving a workout aggregates exercise info and stores it in SQLite."""
@@ -47,7 +52,19 @@ def test_save_workout_success(app_client, db_conn):
     
     r = app_client.post("/workouts", json=payload)
     assert r.status_code == 200
-    assert r.json() == {"status": "success", "message": "Workout saved successfully!"}
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["message"] == "Workout saved successfully!"
+
+    # Gamification rewards: 5 sets, 54 reps, 45 minutes
+    # XP = 50 (base) + 5*10 (sets) + 54 (reps) + 45*2 (minutes) = 244
+    rewards = body["rewards"]
+    assert rewards["xp_gained"] == 244
+    assert rewards["new_level"] >= rewards["old_level"]
+    assert rewards["total_xp"] >= rewards["xp_gained"]
+    assert "rank" in rewards and "title" in rewards["rank"]
+    assert isinstance(rewards["new_achievements"], list)
+    assert 0 <= rewards["progress_pct"] <= 100
 
     # Verify rows in database
     rows = db_conn.execute(


### PR DESCRIPTION
Turn the workout tracker into a game-like experience:

- XP & levels: every saved workout earns XP (base + per set/rep/minute),
  derived retroactively from workout history so no schema change is
  needed. Player card shows level, rank title, animated XP progress bar,
  day streak and career stats.
- Live session HUD: completing a set pops a floating "+XP" particle,
  bumps the session score, and consecutive sets build a combo flame.
- Victory screen: finishing a workout opens a celebration modal with
  confetti, 1-3 stars, XP count-up, level-up banner and newly unlocked
  achievements, all backed by server-computed rewards in the POST
  response.
- Achievements tab: 12 badges (workouts, sets, reps, streaks, marathon,
  variety) with unlock progress bars.
- Skill quest map: progressions are now game stages with
  locked/current/conquered states, a per-skill progress bar, and a
  "conquered" toggle persisted in localStorage.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HXYiCkCbP9mrAHN7V24imJ